### PR TITLE
Add the foam for insulation, thickness 80cm

### DIFF
--- a/include/AnalysisManager.hh
+++ b/include/AnalysisManager.hh
@@ -124,7 +124,6 @@ class AnalysisManager {
     G4double edepInMuonFinderY;
     G4double edepInHadAborb;
     G4double edepInMuonFinderAbsorb;
-    G4double edepInCryGap;
     G4double missCountedEnergy;
 
     G4int    nFromFSLParticles;

--- a/include/DetectorConstructionMaterial.hh
+++ b/include/DetectorConstructionMaterial.hh
@@ -16,13 +16,14 @@ class DetectorConstructionMaterial {
     static DetectorConstructionMaterial* theDetectorConstructionMaterial;
 
   private:
-    G4Element *elH, *elD, *elHe, *elLi, *elBe, *elC, *elN;
-    G4Element *elNe, *elAl, *elFe, *elCu, *elW, *elPb, *elU, *elO;
-    G4Element *elCa, *elNa, *elSi, *elS;
+    G4Element *elH, *elD, *elHe, *elLi, *elBe, *elC, *elN, *elO;
+    G4Element *elNe, *elNa, *elMg, *elAl, *elSi, *elS, *elCa, *elTi, *elFe, *elCu, *elW, *elPb, *elU;
 
     G4Material *Aluminium, *FakeAluminium, *Iron, *Copper, *Tungsten, *Lead;
+    G4Material *SiO2, *Al2O3, *Fe2O3, *CaO, *MgO, *Na2O, *TiO2;
     G4Material *Air, *Vacuum, *ArgonGas, *StainlessSteel, *Nickel; 
     G4Material *LiquidArgon, *LiquidKrypton, *LS, *polystyrene;
+    G4Material *fibrous_glass, *polyurethane_foam, *R_PUF;
 };
 
 #endif

--- a/include/FLArEDetectorConstruction.hh
+++ b/include/FLArEDetectorConstruction.hh
@@ -35,6 +35,7 @@ class FLArEDetectorConstruction : public G4VUserDetectorConstruction {
 
     G4LogicalVolume* worldLog;
     G4LogicalVolume* lArBoxLog;
+    G4LogicalVolume* cryoInsulationLog;
     G4LogicalVolume* hadCatcherLogical;
     G4LogicalVolume* HadCalXCellLogical;
     G4LogicalVolume* HadCalYCellLogical;
@@ -43,7 +44,6 @@ class FLArEDetectorConstruction : public G4VUserDetectorConstruction {
     G4LogicalVolume* MuonFinderYCellLogical;
     G4LogicalVolume* HadAbsorLayersLogical;
     G4LogicalVolume* MuonFinderAbsorLayersLogical;
-    G4LogicalVolume* crygapLogical;
     G4LogicalVolume* TPCModuleLogical;
     G4LogicalVolume* FASER2MagnetYoke;
     G4LogicalVolume* FASER2MagnetWindow;

--- a/src/AnalysisManager.cc
+++ b/src/AnalysisManager.cc
@@ -140,7 +140,6 @@ void AnalysisManager::bookEvtTree() {
   evt->Branch("edepInMuonFinderY"         , &edepInMuonFinderY         , "edepInMuonFinderY/D");
   evt->Branch("edepInHadAborb"            , &edepInHadAborb            , "edepInHadAborb/D");
   evt->Branch("edepInMuonFinderAbsorb"    , &edepInMuonFinderAbsorb    , "edepInMuonFinderAbsorb/D");
-  evt->Branch("edepInCryGap"              , &edepInCryGap              , "edepInCryGap/D");
   evt->Branch("missCountedEnergy"         , &missCountedEnergy         , "missCountedEnergy/D");
   
   evt->Branch("nFromFSLParticles"         , &nFromFSLParticles         , "nFromFSLParticles/I");
@@ -228,7 +227,6 @@ void AnalysisManager::BeginOfEvent() {
   edepInMuonFinderY            = 0;
   edepInHadAborb               = 0;
   edepInMuonFinderAbsorb       = 0;
-  edepInCryGap                 = 0;
   missCountedEnergy            = 0;
   nPrimaryParticle             = 0;
   nFromFSLParticles            = 0;
@@ -372,8 +370,8 @@ void AnalysisManager::EndOfEvent(const G4Event* event) {
   if (!hcofEvent) return;
 
   // loop over all sensitive detectors
-  const G4int nsds = 10;
-  G4int sdids[nsds] = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+  const G4int nsds = 9;
+  G4int sdids[nsds] = {-1, -1, -1, -1, -1, -1, -1, -1, -1};
   std::string sds[nsds] = {"lArBoxSD/lar_box",
                            "HadCalXSD/lar_box",
                            "HadCalYSD/lar_box",
@@ -381,7 +379,6 @@ void AnalysisManager::EndOfEvent(const G4Event* event) {
                            "MuonFinderYSD/lar_box",
                            "HadAbsorbSD/lar_box",
                            "MuonFinderAbsorbSD/lar_box",
-                           "CryGapSD/lar_box",
                            "TrkHorScinSD/lar_box",
                            "TrkVerScinSD/lar_box"};
 
@@ -590,9 +587,8 @@ void AnalysisManager::FillPrimaryTruthTree(G4int sdId, std::string sdName) {
           {"MuonFinderYSD/lar_box",      [&](){ detID = 5; }},
           {"HadAbsorbSD/lar_box",        [&](){ detID = 6; }},
           {"MuonFinderAbsorbSD/lar_box", [&](){ detID = 7; }},
-          {"CryGapSD/lar_box",           [&](){ detID = 8; }},
-          {"TrkHorScinSD/lar_box",       [&](){ detID = 9; }},
-          {"TrkVerScinSD/lar_box",       [&](){ detID = 10; }},
+          {"TrkHorScinSD/lar_box",       [&](){ detID = 8; }},
+          {"TrkVerScinSD/lar_box",       [&](){ detID = 9; }},
   };
   detIDs.find(sdName)->second();
 
@@ -696,9 +692,6 @@ void AnalysisManager::FillPrimaryTruthTree(G4int sdId, std::string sdName) {
         case 7:
           edepInMuonFinderAbsorb += hit->GetEdep();
           break;
-        case 8:
-          edepInCryGap += hit->GetEdep();
-          break;	
       }
 
       // save FSL (only muons!) hits for circle fitting
@@ -712,13 +705,13 @@ void AnalysisManager::FillPrimaryTruthTree(G4int sdId, std::string sdName) {
           hitZFSL.push_back(post_z);
           hitPFSL.push_back(p_perp);
         }
-        else if( detID > 8 && post_z < circularfitter::fMagnetZPos){
+        else if( detID > 7 && post_z < circularfitter::fMagnetZPos){
           preTrkXFSL.push_back(post_x);
           preTrkYFSL.push_back(post_y);
           preTrkZFSL.push_back(post_z);
           preTrkPFSL.push_back(p_perp);
         }
-        else if ( detID > 8 && post_z > circularfitter::fMagnetZPos){
+        else if ( detID > 7 && post_z > circularfitter::fMagnetZPos){
           postTrkXFSL.push_back(post_x);
           postTrkYFSL.push_back(post_y);
           postTrkZFSL.push_back(post_z);
@@ -822,9 +815,8 @@ void AnalysisManager::FillTrueEdep(G4int sdId, std::string sdName) {
           {"MuonFinderYSD/lar_box",      [&](){ detID = 5; }},
           {"HadAbsorbSD/lar_box",        [&](){ detID = 6; }},
           {"MuonFinderAbsorbSD/lar_box", [&](){ detID = 7; }},
-          {"CryGapSD/lar_box",           [&](){ detID = 8; }},
-          {"TrkHorScinSD/lar_box",       [&](){ detID = 9; }},
-          {"TrkVerScinSD/lar_box",       [&](){ detID = 10; }},
+          {"TrkHorScinSD/lar_box",       [&](){ detID = 8; }},
+          {"TrkVerScinSD/lar_box",       [&](){ detID = 9; }},
   };
   detIDs.find(sdName)->second();
 

--- a/src/DetectorConstructionMaterial.cc
+++ b/src/DetectorConstructionMaterial.cc
@@ -17,61 +17,68 @@ DetectorConstructionMaterial::DetectorConstructionMaterial() {
   //------------
 
   a=1.01*g/mole;
-  elH=new G4Element(name="Hydrogen",symbol="H2",z=1.,a);
+  elH=new G4Element(name="hydrogen",symbol="H2",z=1.,a);
 
   a=2.01*g/mole;
-  elD=new G4Element(name="Deuterium",symbol="D",z=1.,a);
+  elD=new G4Element(name="deuterium",symbol="D",z=1.,a);
 
   a=4.*g/mole;
-  elHe=new G4Element(name="Helium",symbol="He",z=2.,a);
+  elHe=new G4Element(name="helium",symbol="He",z=2.,a);
 
   a=6.94*g/mole;
-  elLi=new G4Element(name="Lithium",symbol="Li",z=3.,a);
+  elLi=new G4Element(name="lithium",symbol="Li",z=3.,a);
 
   a=9.01*g/mole;
-  elBe=new G4Element(name="Berillium",symbol="Be",z=4.,a);
+  elBe=new G4Element(name="berillium",symbol="Be",z=4.,a);
 
   a=12.01*g/mole;
-  elC=new G4Element(name="Carbon",symbol="C",z=6.,a);
+  elC=new G4Element(name="carbon",symbol="C",z=6.,a);
 
   a=14.01*g/mole;
-  elN=new G4Element(name="Nitrogen",symbol="N2",z=7.,a);
+  elN=new G4Element(name="nitrogen",symbol="N2",z=7.,a);
 
   a=16.*g/mole;
-  elO=new G4Element(name="Oxygen",symbol="O2",z=8.,a);
+  elO=new G4Element(name="oxygen",symbol="O2",z=8.,a);
 
   a=20.18*g/mole;
-  elNe=new G4Element(name="Neon",symbol="Ne",z=10.,a);
+  elNe=new G4Element(name="neon",symbol="Ne",z=10.,a);
 
   a=22.99*g/mole;
-  elNa=new G4Element(name="Sodium",symbol="Na",z=11.,a);
+  elNa=new G4Element(name="sodium",symbol="Na",z=11.,a);
+
+  a=24.305*g/mole;
+  elMg=new G4Element(name="magnesium",symbol="Mg",z=12.,a);
 
   a=26.98*g/mole;
-  elAl=new G4Element(name="Aluminium",symbol="Al",z=13.,a);
+  elAl=new G4Element(name="aluminium",symbol="Al",z=13.,a);
 
   a=28.085*g/mole;
-  elSi=new G4Element(name="Silicon",symbol="Si",z=14.,a);
-
-  a=40.08*g/mole;
-  elCa=new G4Element(name="Calcium",symbol="Ca",z=20.,a);
-
-  a=55.850*g/mole;
-  elFe=new G4Element(name="Iron",symbol="Fe",z=26.,a);
-
-  a=63.54*g/mole;
-  elCu=new G4Element(name="Copper",symbol="Cu",z=29.,a);
-
-  a=183.85*g/mole;
-  elW=new G4Element(name="Tungstenm",symbol="W",z=74.,a);
-
-  a=207.19*g/mole;
-  elPb=new G4Element(name="Lead",symbol="Pb",z=82.,a);
-
-  a=238.03*g/mole;
-  elU=new G4Element(name="Uranium",symbol="U",z=92.,a);
+  elSi=new G4Element(name="silicon",symbol="Si",z=14.,a);
 
   a=32.06*g/mole;
-  elS=new G4Element(name="Sulfur",symbol="S",z=16.,a);
+  elS=new G4Element(name="sulfur",symbol="S",z=16.,a);
+
+  a=40.08*g/mole;
+  elCa=new G4Element(name="calcium",symbol="Ca",z=20.,a);
+
+  a=47.867*g/mole;
+  elTi=new G4Element(name="titanium",symbol="Ti",z=22.,a);
+
+  a=55.850*g/mole;
+  elFe=new G4Element(name="iron",symbol="Fe",z=26.,a);
+
+  a=63.54*g/mole;
+  elCu=new G4Element(name="copper",symbol="Cu",z=29.,a);
+
+  a=183.85*g/mole;
+  elW=new G4Element(name="tungstenm",symbol="W",z=74.,a);
+
+  a=207.19*g/mole;
+  elPb=new G4Element(name="lead",symbol="Pb",z=82.,a);
+
+  a=238.03*g/mole;
+  elU=new G4Element(name="uranium",symbol="U",z=92.,a);
+
 
   //-------------------
   // simple materials
@@ -113,7 +120,6 @@ DetectorConstructionMaterial::DetectorConstructionMaterial() {
   density = 8.96*g/cm3;
   a = 58.69*g/mole;
   Nickel = new G4Material(name="Nickel",z=28.,a,density);
-
   
   //------------------
   // mixtures
@@ -131,8 +137,42 @@ DetectorConstructionMaterial::DetectorConstructionMaterial() {
 			  kStateGas,temperature,pressure);
   Vacuum->AddMaterial(Air, fractionmass=1.);
 
-  // must have the right composition for stainless steel
+  density = 2.2*g/cm3;
+  SiO2 = new G4Material(name="SiO2", density, nel=2);
+  SiO2->AddElement(elSi, 1);
+  SiO2->AddElement(elO, 2);
 
+  density = 3.97*g/cm3;
+  Al2O3 = new G4Material(name="Al2O3", density, nel=2);
+  Al2O3->AddElement(elAl, 2);
+  Al2O3->AddElement(elO, 3);
+
+  density = 5.24*g/cm3;
+  Fe2O3 = new G4Material(name="Fe2O3", density, nel=2);
+  Fe2O3->AddElement(elFe, 2);
+  Fe2O3->AddElement(elO, 3);
+
+  density = 3.35*g/cm3;
+  CaO = new G4Material(name="CaO", density, nel=2);
+  CaO->AddElement(elCa, 1);
+  CaO->AddElement(elO, 1);
+
+  density = 3.58*g/cm3;
+  MgO = new G4Material(name="MgO", density, nel=2);
+  MgO->AddElement(elMg, 1);
+  MgO->AddElement(elO, 1);
+
+  density = 2.27*g/cm3;
+  Na2O = new G4Material(name="Na2O", density, nel=2);
+  Na2O->AddElement(elNa, 2);
+  Na2O->AddElement(elO, 1);
+
+  density = 4.23*g/cm3;
+  TiO2 = new G4Material(name="TiO2", density, nel=2);
+  TiO2->AddElement(elTi, 1);
+  TiO2->AddElement(elO, 2);
+
+  // must have the right composition for stainless steel
   density = 8.96*g/cm3;
   StainlessSteel = new G4Material(name="StainlessSteel",density,nel=1);
   StainlessSteel->AddElement(elO, fractionmass = 1.);
@@ -154,6 +194,37 @@ DetectorConstructionMaterial::DetectorConstructionMaterial() {
   polystyrene = new G4Material("Polystyrene", density, nel=2);
   polystyrene->AddElement(elC, natoms=19);
   polystyrene->AddElement(elH, natoms=21);
+
+  density = 2.58*g/cm3;
+  fibrous_glass = new G4Material("fibrous_glass", density, 7);
+  fibrous_glass->AddMaterial(SiO2 , 0.600);
+  fibrous_glass->AddMaterial(Al2O3, 0.118);
+  fibrous_glass->AddMaterial(Fe2O3, 0.001);
+  fibrous_glass->AddMaterial(CaO  , 0.224);
+  fibrous_glass->AddMaterial(MgO  , 0.034);
+  fibrous_glass->AddMaterial(Na2O , 0.010);
+  fibrous_glass->AddMaterial(TiO2 , 0.013);
+
+  // The following fractional components are placeholders,
+  // to be fixed (though they have very little effect,
+  // as long as the density is correct)
+  density = 0.13*g/cm3;
+  polyurethane_foam = new G4Material("polyurethane_foam", density, 7);
+  polyurethane_foam->AddMaterial(SiO2 , 0.600);
+  polyurethane_foam->AddMaterial(Al2O3, 0.118);
+  polyurethane_foam->AddMaterial(Fe2O3, 0.001);
+  polyurethane_foam->AddMaterial(CaO  , 0.224);
+  polyurethane_foam->AddMaterial(MgO  , 0.034);
+  polyurethane_foam->AddMaterial(Na2O , 0.010);
+  polyurethane_foam->AddMaterial(TiO2 , 0.013);
+
+  // for the cryostat foam insulation: Reinforced polyurethane foam
+  // Source
+  // https://github.com/DUNE/dunecore/blob/b0269b11c6ad9acde6a59db6ea7fd46e88318273/dunecore/Geometry/gdml/dune35t4apa_v4_3mmpitch_nowires.gdml#L203-L208
+  density = 0.2525*g/cm3;
+  R_PUF = new G4Material("R_PUF", density, 2);
+  R_PUF->AddMaterial(polyurethane_foam, 0.95);
+  R_PUF->AddMaterial(fibrous_glass    , 0.05);
 }
 
 DetectorConstructionMaterial* DetectorConstructionMaterial::GetInstance() {
@@ -180,6 +251,7 @@ G4Material* DetectorConstructionMaterial::Material(G4String what) {
   if(what == "Nickel")             material = Nickel;
   if(what == "LiquidScintillator") material = LS;
   if(what == "Polystyrene")        material = polystyrene;
+  if(what == "R_PUF")              material = R_PUF;
 
   return material;
 }


### PR DESCRIPTION
I added the material and geometry for a simplified insulation layer. The property of the material comes from [DUNE's code](https://github.com/DUNE/dunecore/blob/b0269b11c6ad9acde6a59db6ea7fd46e88318273/dunecore/Geometry/gdml/dune35t4apa_v4_3mmpitch_nowires.gdml#L203-L208). The thickness of the R-PUF is set to 80 cm, which is larger than the previous fake gap between the TPC volume and the HadCal. I had to adjust the location a bit. That fake gap used to be one of the sensitive detectors, so I had to remove that from `FLArEDetectorConstruction.cc` and `AnalysisManager.cc`. The indices of the sensitive detectors in `AnalysisManager.cc` changed accordingly.