### PR TITLE
add scripts to submit grid jobs for nue and nutau

### DIFF
--- a/GridUtils/nue/batch_script.sh
+++ b/GridUtils/nue/batch_script.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+umask 002
+echo "Process Number"
+echo $PROCESS
+whoami
+uname -a
+cat /etc/issue
+cat /proc/cpuinfo
+
+export DISPLAY=0
+
+source /cvmfs/dune.opensciencegrid.org/products/dune/setup_dune.sh
+setup dunetpc v09_25_00 -q e20:prof
+setup cmake v3_20_0
+setup gcc v9_3_0
+
+filelist=$1
+geofile_full=$2
+mymacro_full=$3
+outputpath=$4
+
+my_condor_work=${_CONDOR_SCRATCH_DIR}/work
+
+mkdir -p ${my_condor_work}
+cd ${my_condor_work}
+
+ifdh cp /pnfs/dune/persistent/users/wenjiewu/flare/nue/nue_kling_ar40_e5000.ghep.root nue_kling_ar40_e5000.ghep.root
+ifdh cp --cp_maxretries=1 -D $filelist ./
+listname=`basename "$filelist"`
+
+ifdh cp --cp_maxretries=1 -D $geofile_full ./
+
+let num=$PROCESS*1+1
+echo $listname $num
+input=$(tail -n+${num} $listname | head -n1)
+
+#inputfile=$(echo $input | awk -F'/' '{print $NF}')
+inputpath=`dirname "$input"`
+inputfile=`basename "$input"`
+
+mymacro=`basename "$mymacro_full"`
+
+echo Input: ${inputpath}/${inputfile}
+echo Copy Input file and My Macro
+ifdh cp --cp_maxretries=1 -D ${input} ./
+ifdh cp --cp_maxretries=1 -D ${mymacro_full} ./
+chmod 777 ${mymacro}
+ls -lhrt
+
+output=$(cat ${inputfile} | grep 'fileName' | awk -F' ' '{print $2}')
+output_log=log_${output%.root}.log
+output_h5=${output%.root}.h5
+echo Ouput: ${output}
+
+echo Run my macro
+#root -l -q -b `printf "${mymacro}(\"$inputfile\",$pdg,\"$output\")" ` | tee ${output_log}
+./${mymacro} $inputfile | tee ${output_log}
+echo "Done my macro"
+ls -lhrt
+
+echo "Copying out files"
+echo ${output} to ${outputpath}
+ifdh cp --cp_maxretries=5 -D ${output} ${outputpath} || exit 14
+ifdh cp --cp_maxretries=5 -D ${output_h5} ${outputpath} || exit 15
+ifdh cp --cp_maxretries=5 -D ${output_log} ${outputpath} || exit 16
+
+cd ${_CONDOR_SCRATCH_DIR}
+rm -rf *
+ls -lhrt

--- a/GridUtils/nue/nue_job.sh
+++ b/GridUtils/nue/nue_job.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+function genenerate_macros {
+  num_evt_per_file=$1; shift
+  num_file=$1; shift
+  loc_list=$1; shift  
+  geomacro=$1; shift
+  
+  geoname=${geomacro%%.*}
+  echo $geoname
+
+  for i in `seq 1 1 ${num_file}`
+  do
+    seed1=$((42+i))
+    seed2=$((47+i))
+
+    istart=$((num_evt_per_file*i-num_evt_per_file))
+    filename="/pnfs/dune/scratch/users/wenjiewu/FLArE/macro_savePM/nue_macro/nue_${geoname}_Fid_${i}.mac"
+    outputfile="nue_${geoname}_fid_${i}.root"
+    if [ -f ${filename} ]; then
+      echo "${filename} exists, delete file first"
+      ifdh rm ${filename}
+    fi
+    echo $filename >> $loc_list
+    rm temp.mac
+cat << EOF >> temp.mac
+/control/execute ${geomacro}
+
+/random/setSeeds ${seed1} ${seed2}
+/run/initialize
+
+/genie/useGenie true
+/genie/genieInput nue_kling_ar40_e5000.ghep.root
+/genie/genieIStart ${istart}
+
+/histo/addDiffusion false
+/histo/saveHit false
+/histo/save3DEvd true
+/histo/save2DEvd false
+/histo/circleFit true
+/histo/fileName ${outputfile}
+
+/run/beamOn ${num_evt_per_file}
+EOF
+ 
+  ifdh cp --cp_maxretries=1 temp.mac ${filename}
+  done
+}
+
+n_evt_per_file=200
+n_files=500
+geomacro="FLArE_only.mac"
+geoname=${geomacro%%.*}
+geofile="/pnfs/dune/scratch/users/wenjiewu/FLArE/macro_savePM/${geomacro}"
+list="/pnfs/dune/scratch/users/wenjiewu/FLArE/macro_savePM/nue_${geoname}_macros_list.txt"
+exe="/pnfs/dune/scratch/users/wenjiewu/FLArE/FLArE"
+out="/pnfs/dune/scratch/users/wenjiewu/FLArE/nue/${geoname}"
+
+ifdh rm ${exe} 
+ifdh rm ${geofile}
+ifdh cp ../../FLArE ${exe}
+ifdh cp ../../macros/geometry_options/${geomacro} ${geofile}
+mkdir -p ${out}
+rm ${out}/*
+
+local_list="temp.txt"
+
+if [ -f ${list} ]; then
+  rm ${list}
+fi
+if [ -f ${local_list} ]; then
+  rm ${local_list}
+fi
+touch $list
+  
+genenerate_macros $n_evt_per_file $n_files $local_list $geomacro
+
+ifdh rm $list
+ifdh cp $local_list $list
+source submit.sh $list $geofile $exe $out
+
+

--- a/GridUtils/nue/submit.sh
+++ b/GridUtils/nue/submit.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+file_list=$1 # one text file contains location of all the run configuration files
+geofile=$2   # path to configuration file containing the geometry
+macro=$3     # executive file of the main program (here the geant4 program)
+out_dir=$4   # output directory
+
+if [ -d "${out_dir}" ]; then
+  if [ "$(ls -A ${out_dir})" ]; then
+    echo "Take action ${out_dir} is not empty"
+    return 1
+  else
+    echo "${out_dir} is empty"
+    echo "submitting job(s)"
+  fi
+else
+  echo "${out_dir} is not found"
+  return 1
+fi
+
+n_jobs=`wc -l $file_list | cut -f1 -d' '`
+jobsub_submit -N $n_jobs -G dune --expected-lifetime=10h --memory=40000MB --disk=8GB --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE file://./batch_script.sh $file_list $geofile $macro $out_dir

--- a/GridUtils/nutau/batch_script.sh
+++ b/GridUtils/nutau/batch_script.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+umask 002
+echo "Process Number"
+echo $PROCESS
+whoami
+uname -a
+cat /etc/issue
+cat /proc/cpuinfo
+
+export DISPLAY=0
+
+source /cvmfs/dune.opensciencegrid.org/products/dune/setup_dune.sh
+setup dunetpc v09_25_00 -q e20:prof
+setup cmake v3_20_0
+setup gcc v9_3_0
+
+filelist=$1
+geofile_full=$2
+mymacro_full=$3
+outputpath=$4
+
+my_condor_work=${_CONDOR_SCRATCH_DIR}/work
+
+mkdir -p ${my_condor_work}
+cd ${my_condor_work}
+
+ifdh cp /pnfs/dune/persistent/users/wenjiewu/flare/nutau/nutau_bai_ar40_e2000.ghep.root nutau_bai_ar40_e2000.ghep.root
+ifdh cp --cp_maxretries=1 -D $filelist ./
+listname=`basename "$filelist"`
+
+ifdh cp --cp_maxretries=1 -D $geofile_full ./
+
+let num=$PROCESS*1+1
+echo $listname $num
+input=$(tail -n+${num} $listname | head -n1)
+
+#inputfile=$(echo $input | awk -F'/' '{print $NF}')
+inputpath=`dirname "$input"`
+inputfile=`basename "$input"`
+
+mymacro=`basename "$mymacro_full"`
+
+echo Input: ${inputpath}/${inputfile}
+echo Copy Input file and My Macro
+ifdh cp --cp_maxretries=1 -D ${input} ./
+ifdh cp --cp_maxretries=1 -D ${mymacro_full} ./
+chmod 777 ${mymacro}
+ls -lhrt
+
+output=$(cat ${inputfile} | grep 'fileName' | awk -F' ' '{print $2}')
+output_log=log_${output%.root}.log
+output_h5=${output%.root}.h5
+echo Ouput: ${output}
+
+echo Run my macro
+#root -l -q -b `printf "${mymacro}(\"$inputfile\",$pdg,\"$output\")" ` | tee ${output_log}
+./${mymacro} $inputfile | tee ${output_log}
+echo "Done my macro"
+ls -lhrt
+
+echo "Copying out files"
+echo ${output} to ${outputpath}
+ifdh cp --cp_maxretries=5 -D ${output} ${outputpath} || exit 14
+ifdh cp --cp_maxretries=5 -D ${output_h5} ${outputpath} || exit 15
+ifdh cp --cp_maxretries=5 -D ${output_log} ${outputpath} || exit 16
+
+cd ${_CONDOR_SCRATCH_DIR}
+rm -rf *
+ls -lhrt

--- a/GridUtils/nutau/nutau_job.sh
+++ b/GridUtils/nutau/nutau_job.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+function genenerate_macros {
+  num_evt_per_file=$1; shift
+  num_file=$1; shift
+  loc_list=$1; shift  
+  geomacro=$1; shift
+  
+  geoname=${geomacro%%.*}
+  echo $geoname
+
+  for i in `seq 1 1 ${num_file}`
+  do
+    seed1=$((42+i))
+    seed2=$((47+i))
+
+    istart=$((num_evt_per_file*i-num_evt_per_file))
+    filename="/pnfs/dune/scratch/users/wenjiewu/FLArE/macro_savePM/nutau_macro/${geoname}_Fid_${i}.mac"
+    outputfile="nutau_${geoname}_fid_${i}.root"
+    if [ -f ${filename} ]; then
+      echo "${filename} exists, delete file first"
+      ifdh rm ${filename}
+    fi
+    echo $filename >> $loc_list
+    rm temp.mac
+cat << EOF >> temp.mac
+/control/execute ${geomacro}
+
+/random/setSeeds ${seed1} ${seed2}
+/run/initialize
+
+/genie/useGenie true
+/genie/genieInput nutau_bai_ar40_e2000.ghep.root
+/genie/genieIStart ${istart}
+
+/histo/addDiffusion false
+/histo/saveHit false
+/histo/save3DEvd true
+/histo/save2DEvd false
+/histo/circleFit true
+/histo/fileName ${outputfile}
+
+/run/beamOn ${num_evt_per_file}
+EOF
+ 
+  ifdh cp --cp_maxretries=1 temp.mac ${filename}
+  done
+}
+
+n_evt_per_file=200
+n_files=500
+geomacro="FLArE_only.mac"
+geoname=${geomacro%%.*}
+geofile="/pnfs/dune/scratch/users/wenjiewu/FLArE/macro_savePM/${geomacro}"
+list="/pnfs/dune/scratch/users/wenjiewu/FLArE/macro_savePM/nutau_${geoname}_macros_list.txt"
+exe="/pnfs/dune/scratch/users/wenjiewu/FLArE/FLArE"
+out="/pnfs/dune/scratch/users/wenjiewu/FLArE/nutau/${geoname}"
+
+ifdh rm ${exe} 
+ifdh rm ${geofile}
+ifdh cp ../../FLArE ${exe}
+ifdh cp ../../macros/geometry_options/${geomacro} ${geofile}
+mkdir -p ${out}
+rm ${out}/*
+
+local_list="temp.txt"
+
+if [ -f ${list} ]; then
+  rm ${list}
+fi
+if [ -f ${local_list} ]; then
+  rm ${local_list}
+fi
+touch $list
+  
+genenerate_macros $n_evt_per_file $n_files $local_list $geomacro
+
+ifdh rm $list
+ifdh cp $local_list $list
+source submit.sh $list $geofile $exe $out
+
+

--- a/GridUtils/nutau/submit.sh
+++ b/GridUtils/nutau/submit.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+file_list=$1 # one text file contains location of all the run configuration files
+geofile=$2   # path to configuration file containing the geometry
+macro=$3     # executive file of the main program (here the geant4 program)
+out_dir=$4   # output directory
+
+if [ -d "${out_dir}" ]; then
+  if [ "$(ls -A ${out_dir})" ]; then
+    echo "Take action ${out_dir} is not empty"
+    return 1
+  else
+    echo "${out_dir} is empty"
+    echo "submitting job(s)"
+  fi
+else
+  echo "${out_dir} is not found"
+  return 1
+fi
+
+n_jobs=`wc -l $file_list | cut -f1 -d' '`
+jobsub_submit -N $n_jobs -G dune --expected-lifetime=8h --memory=24000MB --disk=8GB --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE file://./batch_script.sh $file_list $geofile $macro $out_dir


### PR DESCRIPTION
It's a simple copy and paste from the numu folder, to add the necessary scripts for grid jobs submission for nue and nutau.

There are hardcoded paths that need to be modified. Every time we do a new build, cmake would copy these scripts and replace the ones in the build directory. Then we need to modify those hardcoded paths every time, which is annoying. I don't have a good solution for this. The way I'm doing now is to save the modified scripts in a separate folder, so they won't be automatically replaced.