### PR TITLE
Bug fix: FORMOSA size

### DIFF
--- a/include/geometry/FORMOSADetectorConstruction.hh
+++ b/include/geometry/FORMOSADetectorConstruction.hh
@@ -34,8 +34,8 @@ class FORMOSADetectorConstruction {
     G4LogicalVolume* fScintillatorPMT;
 
     // Scintillator bars
-    G4int fNScintillatorBarsX;
-    G4int fNScintillatorBarsY;
+    G4int fNScinBarsX;
+    G4int fNScinBarsY;
     G4double fScintillatorBarSizeX;
     G4double fScintillatorBarSizeY;
     G4double fScintillatorBarSizeZ;

--- a/include/geometry/GeometricalParameters.hh
+++ b/include/geometry/GeometricalParameters.hh
@@ -127,10 +127,10 @@ class GeometricalParameters  {
     void SetFORMOSATotalSizeZ(G4double val) { fFORMOSATotalSizeZ = val; }
     G4double GetFORMOSATotalSizeZ() { return fFORMOSATotalSizeZ; }
     // Scintillator blocks
-    void SetNScinBarsX(G4int val) { fNScintillatorBarsX = val; }
-    G4int GetNScinBarsX() {return fNScintillatorBarsX; }
-    void SetNScinBarsY(G4int val) { fNScintillatorBarsY = val; }
-    G4int GetNScinBarsY() {return fNScintillatorBarsY; }
+    void SetNScinBarsX(G4int val) { fNScinBarsX = val; }
+    G4int GetNScinBarsX() {return fNScinBarsX; }
+    void SetNScinBarsY(G4int val) { fNScinBarsY = val; }
+    G4int GetNScinBarsY() {return fNScinBarsY; }
     void SetScintillatorBarSizeX(G4double val) { fScintillatorBarSizeX = val; }
     G4double GetScintillatorBarSizeX() {return fScintillatorBarSizeX; }
     void SetScintillatorBarSizeY(G4double val) { fScintillatorBarSizeY = val; }

--- a/macros/vis.mac
+++ b/macros/vis.mac
@@ -9,6 +9,7 @@
 #
 /run/initialize
 #
+/control/execute macros/geometry_options/FPF_hall_Reference.mac
 
 #/vis/open DAWNFILE
 # Use this open statement to create an OpenGL view:

--- a/src/geometry/FORMOSADetectorConstruction.cc
+++ b/src/geometry/FORMOSADetectorConstruction.cc
@@ -18,8 +18,8 @@ FORMOSADetectorConstruction::FORMOSADetectorConstruction()
 
   G4cout << "Building FORMOSA Detector" << G4endl;
 
-  fNScintillatorBarsX = GeometricalParameters::Get()->GetNScinBarsX();
-  fNScintillatorBarsY = GeometricalParameters::Get()->GetNScinBarsY();
+  fNScinBarsX = GeometricalParameters::Get()->GetNScinBarsX();
+  fNScinBarsY = GeometricalParameters::Get()->GetNScinBarsY();
   fScintillatorBarSizeX = GeometricalParameters::Get()->GetScintillatorBarSizeX();
   fScintillatorBarSizeY = GeometricalParameters::Get()->GetScintillatorBarSizeY();
   fScintillatorBarSizeZ = GeometricalParameters::Get()->GetScintillatorBarSizeZ();
@@ -84,26 +84,26 @@ void FORMOSADetectorConstruction::BuildScintillatorAssembly()
 
   // build scintillator block
   auto scinBlockSolid = new G4Box("scinBlockSolid",
-                               (fNScintillatorBarsX*fScintillatorBarSizeX)/2.,
-                               (fNScintillatorBarsY*fScintillatorBarSizeY)/2.,
+                               (fNScinBarsX*fScintillatorBarSizeX)/2.,
+                               (fNScinBarsY*fScintillatorBarSizeY)/2.,
                                fScintillatorBarSizeZ/2.);
   auto scinBlockLogical = new G4LogicalVolume(scinBlockSolid, fMaterials->Material("Polystyrene"), "scinBlockLogical");
   auto scinBlockYLayerSolid = new G4Box("scinBlockYLayerSolid",
-                               (fNScintillatorBarsX*fScintillatorBarSizeX)/2.,
+                               (fNScinBarsX*fScintillatorBarSizeX)/2.,
                                fScintillatorBarSizeY/2.,
                                fScintillatorBarSizeZ/2.);
   auto scinBlockYLayerLogical = new G4LogicalVolume(scinBlockYLayerSolid, fMaterials->Material("Polystyrene"), "scinBlockYLayerLogical");
   // replicate along x to build one Y layer of the block
   new G4PVReplica("scinBlockYLayerPhysical", fScintillatorBar,
-                  scinBlockYLayerLogical, kXAxis, fNScintillatorBarsX, fScintillatorBarSizeX);
+                  scinBlockYLayerLogical, kXAxis, fNScinBarsX, fScintillatorBarSizeX);
   // replicate along y to fill entire block
   new G4PVReplica("scinBlockPhysical", scinBlockYLayerLogical,
-                  scinBlockLogical, kYAxis, fNScintillatorBarsY, fScintillatorBarSizeY);
+                  scinBlockLogical, kYAxis, fNScinBarsY, fScintillatorBarSizeY);
  
   // build PMT "box"
   auto PMTBoxSolid = new G4Box("PMTBoxSolid", 
-                              (fNScintillatorBarsX*fScintillatorBarSizeX)/2.,
-                              (fNScintillatorBarsY*fScintillatorBarSizeY)/2.,
+                              (fNScinBarsX*fScintillatorBarSizeX)/2.,
+                              (fNScinBarsY*fScintillatorBarSizeY)/2.,
                                fPMTSizeSpacing/2.);
   fScintillatorPMT = new G4LogicalVolume(PMTBoxSolid, fMaterials->Material("Air"), "PMTBoxLogical");
 

--- a/src/geometry/GeometricalParameters.cc
+++ b/src/geometry/GeometricalParameters.cc
@@ -64,8 +64,8 @@ GeometricalParameters::GeometricalParameters()
 
   // FORMOSA
   fFORMOSATotalSizeZ = 5*m; //updates during construction
-  fNScintillatorBarsX = 20;
-  fNScintillatorBarsY = 20;
+  fNScinBarsX = 20;
+  fNScinBarsY = 20;
   fScintillatorBarSizeX = 5*cm;
   fScintillatorBarSizeY = 5*cm;
   fScintillatorBarSizeZ = 1*m;


### PR DESCRIPTION
Given the similarity of the variable names, the number of FORMOSA scintillator bars along X and Y was being read from that of the FASER2 tracking stations. As result, instead of the nominal 20 bars, only 7 were in the geometry. The total cross-section was 35cm x 35cm instead of 1m x 1m. 

This might affect the muon acceptance study, as more detector material now sits between FLArE and FASER2. The previous result showed small effects from the addition/removal of FORMOSA+FASERnu2. Now the effect might be slightly larger.

On top of that, all recent screenshots of the FPF cavern options are wrong and must be corrected 😢 