### PR TITLE
Library/dictionary generation in CMakeLists.txt + BabyMIND bug fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ foreach(_file ${macros} ${genie} ${analysis} ${gridutils} ${setup})
 endforeach()
 
 #----------------------------------------------------------------------------
-# generate dictionaries for the custum classes in the ROOT tree
+# generate dictionaries for the custom classes in the ROOT tree
 ROOT_GENERATE_DICTIONARY(DictOutput ${PROJECT_SOURCE_DIR}/include/FPFNeutrino.hh 
                                     ${PROJECT_SOURCE_DIR}/include/FPFParticle.hh 
 				    LINKDEF ${PROJECT_SOURCE_DIR}/include/LinkDef.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ message(STATUS "Set Geant4 : ${Geant4_USE_FILE}")
 find_package(ROOT REQUIRED COMPONENTS Geom EG RIO) 
 include(${ROOT_USE_FILE})
 message(STATUS "Set ROOT : ${ROOT_USE_FILE}")
+message(STATUS "ROOT : ${ROOT_LIBRARIES}")
 
 ## Eigen
 find_package(Eigen3 3.3 REQUIRED NO_MODULE)
@@ -58,16 +59,18 @@ message(STATUS "HEP_HPC lib: ${HEP_HPC_LIBRARIES}")
 include_directories(${ROOT_INCLUDE_DIR} ${Geant4_INCLUDE_DIR} ${EIGEN3_INCLUDE_DIR} ${PROJECT_SOURCE_DIR}/include)
 file(GLOB_RECURSE sources ${PROJECT_SOURCE_DIR}/src/*.cc 
                           ${PROJECT_SOURCE_DIR}/src/reco/*.cc
-                          ${PROJECT_SOURCE_DIR}/src/geometry/*.cc)
+                          ${PROJECT_SOURCE_DIR}/src/geometry/*.cc
+                          ${PROJECT_SOURCE_DIR}/src/fields/*.cc)
 file(GLOB_RECURSE headers ${PROJECT_SOURCE_DIR}/include/*.hh 
                           ${PROJECT_SOURCE_DIR}/include/reco/*.hh
                           ${PROJECT_SOURCE_DIR}/include/utils/*.hh
-                          ${PROJECT_SOURCE_DIR}/include/geometry/*.hh)
+                          ${PROJECT_SOURCE_DIR}/include/geometry/*.hh
+                          ${PROJECT_SOURCE_DIR}/include/fields/*.hh)
 file(GLOB_RECURSE macros RELATIVE ${PROJECT_SOURCE_DIR} macros/*.mac)
 file(GLOB_RECURSE genie RELATIVE ${PROJECT_SOURCE_DIR} genie/*)
 file(GLOB_RECURSE analysis RELATIVE ${PROJECT_SOURCE_DIR} analysis/*)
 file(GLOB_RECURSE gridutils RELATIVE ${PROJECT_SOURCE_DIR} GridUtils/*)
-file(GLOB_RECURSE setup RELATIVE ${PROJECT_SOURCE_DIR} lxplus_setup.sh)
+file(GLOB setup RELATIVE ${PROJECT_SOURCE_DIR} lxplus_setup.sh)
 
 # Enable macros for out-of-source build
 foreach(_file ${macros} ${genie} ${analysis} ${gridutils} ${setup})
@@ -76,28 +79,39 @@ foreach(_file ${macros} ${genie} ${analysis} ${gridutils} ${setup})
     ${PROJECT_BINARY_DIR}/${_file}
     COPYONLY
     )
+    #message(STATUS "Copying ${_file} in ${PROJECT_BINARY_DIR}/${_file}")
 endforeach()
+
+#----------------------------------------------------------------------------
+# generate dictionaries for the custum classes in the ROOT tree
+ROOT_GENERATE_DICTIONARY(DictOutput ${PROJECT_SOURCE_DIR}/include/FPFNeutrino.hh 
+                                    ${PROJECT_SOURCE_DIR}/include/FPFParticle.hh 
+				    LINKDEF ${PROJECT_SOURCE_DIR}/include/LinkDef.h)
+
+# create a shared library that includes the dictionary
+add_library(FPFClasses SHARED ${PROJECT_SOURCE_DIR}/src/FPFNeutrino.cc
+                              ${PROJECT_SOURCE_DIR}/src/FPFParticle.cc
+                              DictOutput.cxx)
+
+# include directories for headers
+target_include_directories(FPFClasses PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
 #----------------------------------------------------------------------------
 # Add the executable, and link it to the Geant4 libraries
 #
 add_executable(FLArE FLArE.cc ${sources} ${headers})
-message(STATUS "ROOT : ${ROOT_LIBRARIES}")
+
 target_link_libraries(FLArE 
   ${ROOT_LIBRARIES} 
   ${Geant4_LIBRARIES} 
   ${HDF5_LIBRARIES}
   ${HEP_HPC_LIBRARIES}
+  FPFClasses
   )
-
-# attach dictionaries to the executable. first, tell it where to look for headers required by the dictionaries:
-target_include_directories(FLArE PRIVATE ${PROJECT_SOURCE_DIR}/include)
-# then generate dictionaries and add them as a dependency of the executable (via the MODULE parameter):
-ROOT_GENERATE_DICTIONARY(DictOutput ${PROJECT_SOURCE_DIR}/include/FPFNeutrino.hh 
-                                    ${PROJECT_SOURCE_DIR}/include/FPFParticle.hh 
-                                    MODULE FLArE LINKDEF ${PROJECT_SOURCE_DIR}/include/LinkDef.h)
 
 #----------------------------------------------------------------------------
 # Install the executable to 'bin' directory under CMAKE_INSTALL_PREFIX
 #
-install(TARGETS FLArE DESTINATION bin)
+install(TARGETS FLArE DESTINATION ${PROJECT_SOURCE_DIR}/bin)
+install(TARGETS FPFClasses DESTINATION ${PROJECT_SOURCE_DIR}/lib)
+install(FILES ${PROJECT_SOURCE_DIR}/build/libDictOutput_rdict.pcm DESTINATION ${PROJECT_SOURCE_DIR}/lib)

--- a/GridUtils/lxplus/nujobs/nu_job.sh
+++ b/GridUtils/lxplus/nujobs/nu_job.sh
@@ -6,26 +6,26 @@
 
 # Production name for output directories
 # This is used to place output logs and files
-export prodname="test_production"
+export prodname="FLArE_FASER2_only_fid"
 
 # Define how many jobs, how many files
 # Jobs will be placed in the same cluster
-export n_jobs=2
-export n_evt_per_job=5
+export n_jobs=500
+export n_evt_per_job=200
 
 # Set the max wall time duration allowed
 # See https://batchdocs.web.cern.ch/tutorial/exercise6b.html
 # eg: espresso = 20 min, microcentury = 1 hour, longlunch = 2 hours
-export max_duration="microcentury"
+export max_duration="longlunch"
 
 # Path to FLArE build directory in /afs/cern.ch
 export builddir="/afs/cern.ch/work/${USER:0:1}/${USER}/public/FLArE/build"
 export flare="${builddir}/FLArE"
 export setup="${builddir}/lxplus_setup.sh"
-export libdict="${builddir}/libFLArE_rdict.pcm"
+export libdict="${builddir}/libDictOutput_rdict.pcm"
 
 # Path to geometry macro in /afs/cern.ch
-export geometry="${builddir}/macros/geometry_options/FPF_hall_Reference.mac"
+export geometry="${builddir}/macros/geometry_options/FLArE_FASER2_only.mac"
 
 # Path to genie gst file in /eos/
 export geniegst="/eos/user/m/mvicenzi/genie/numu_kling_ar40_e5000.gst.root"
@@ -114,6 +114,7 @@ log                     = ${logdir}/${prodname}/log/\$(ClusterId).\$(ProcId).log
 transfer_input_files    = ${setup},${flare},${geometry},${libdict},${listpath}
 output_destination      = root://eosuser.cern.ch/${outdir}/${prodname}/
 MY.XRDCP_CREATE_DIR     = True
+request_memory          = 8000
 +JobFlavour             = "${max_duration}"
 queue ${n_jobs}
 EOF

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ source lxplus_setup.sh
 * Assume the path to the source code is `/path/to/source`.
 * To compile, you need to go to the build directory `cd /path/to/build`.
 * And then `cmake -S /path/to/source -B /path/to/build`.
-* Finally `make`.
+* Finally `make` or `make install`.
 
 The minimal software requirements are:
 * Geant4 v4_10_6_p01c

--- a/src/geometry/BabyMINDDetectorConstruction.cc
+++ b/src/geometry/BabyMINDDetectorConstruction.cc
@@ -66,40 +66,46 @@ BabyMINDDetectorConstruction::BabyMINDDetectorConstruction()
     G4ThreeVector currentPos = prevPos;
 
     switch(c) {
-    
+
       case '|': // start/end of block padding, nothing to place
-        shift += fBlockPadding;
+       
+        // length is spacing from previous + full size
+        shift = fBlockPadding;
         if(prev=='|') shift += fBlockToBlockSpacing;
         currentPos += G4ThreeVector(0.,0.,shift);
         break;
     
-      case 'M': //magnet module (M)
+       case 'M': //magnet module (M)
 
+        // shift to the middle of the module
+        // spacing from previous + half its size
         if( prev == 'M' ) shift += fMagnetToMagnetSpacing;
         else if( prev == 'D' ) shift += fMagnetToScinSpacing;
-
-        shift += fMagnetPlateThickness/2.; 
+        shift += fMagnetPlateThickness/2.;
         currentPos += G4ThreeVector(0.,0.,shift);
         // placing a magnet module
-	fBabyMINDAssembly->AddPlacedVolume(fMagnetPlate,currentPos,noRot);
-        shift += fMagnetPlateThickness/2.; 
+        fBabyMINDAssembly->AddPlacedVolume(fMagnetPlate,currentPos,noRot);
+        // update pointer to the end of the module
+        // shift by only remaining half size
+        shift = fMagnetPlateThickness/2.;
         currentPos += G4ThreeVector(0.,0.,shift);
-
         break;
       
       case 'D': //detector module (D)
         
-	if( prev == 'M' ) shift += fMagnetToScinSpacing;
+        // shift to the middle of the module
+        // spacing from previous + half its size
+        if( prev == 'M' ) shift += fMagnetToScinSpacing;
         else if( prev == 'D' ) shift += fMagnetToScinSpacing;
-        
-	shift += 2*fBarThickness;
+        shift += 2*fBarThickness;
         currentPos += G4ThreeVector(0.,0.,shift);
         // placing a detector module
-	fBabyMINDAssembly->AddPlacedAssembly(fDetectorModule,currentPos,noRot);
-        shift += 2*fBarThickness; 
+        fBabyMINDAssembly->AddPlacedAssembly(fDetectorModule,currentPos,noRot);
+        // update pointer to the end of the module
+        // shift by only remaining half size
+        shift = 2*fBarThickness; 
         currentPos += G4ThreeVector(0.,0.,shift);
-        
-	break;
+        break;
   
       default:
         G4cout << "ERROR: unrecognized char='" << c << "' in block sequence: '" << fBlockSequence << "'" << G4endl;


### PR DESCRIPTION
This PR contains two items:

- Updates to `CMakeLists.txt` to produce a library containing the definition of the output classes (`FPFNeutrino` and `FPFParticle`). The library is named `libFPFClasses.so`. It is automatically installed using `make install` to a folder `\lib` at the path specified by `-DCMAKE_INSTALL_PREFIX` (defaults to the source directory). This makes importing the class definitions in external analysis code simpler.
- Fix to a bug in the BabyMIND geometry: the actual constructed geometry was ending up being longer than its total expected size. The bug was the use of `+=` instead of `=` when accounting for a shift during the placement of the magnet or detector modules. As a result, modules were treated as 1.5 times their actual length leaving larger gaps between them.