### PR TITLE
FPF hall alignment and trajectory tree bugfix

### DIFF
--- a/include/AnalysisManager.hh
+++ b/include/AnalysisManager.hh
@@ -179,6 +179,7 @@ class AnalysisManager {
     int trackTID;                     
     int trackPID;     
     int trackPDG;
+    double trackKinE;
     int trackNPoints;  
     std::vector<double> trackPointX;  
     std::vector<double> trackPointY;  

--- a/include/geometry/GeometricalParameters.hh
+++ b/include/geometry/GeometricalParameters.hh
@@ -20,6 +20,8 @@ class GeometricalParameters  {
 
     // experimental hall
     G4double GetHallHeadDistance() { return fHallHeadDistance; }
+    G4double GetHallOffsetX() { return fHallOffsetX; }
+    G4double GetHallOffsetY() { return fHallOffsetY; }
 
     // FLArE TPC volume
     enum tpcMaterialOption { LiquidArgon, LiquidKrypton};
@@ -199,6 +201,8 @@ class GeometricalParameters  {
 
     // experimental hall
     G4double fHallHeadDistance; ///<- distance between the entrance wall and the first detector
+    G4double fHallOffsetX; // x offset of hall center from the LOS
+    G4double fHallOffsetY; // x offset of hall center from the LOS
 
     // FLArE TPC volume
     tpcMaterialOption fFLArETPCMaterialOption;

--- a/macros/vis.mac
+++ b/macros/vis.mac
@@ -7,9 +7,10 @@
 /run/verbose 2
 
 # Choose the geometry option by importing one of the default macros
-/control/execute macros/geometry_options/FPF_hall_Reference.mac
+#/control/execute macros/geometry_options/FPF_hall_Reference.mac
 #/control/execute macros/geometry_options/FPF_hall_Reference_CP.mac
-#/control/execute macros/geometry_options/FPF_hall_Option1a_FORMOSAlast.mac
+/control/execute macros/geometry_options/FPF_hall_Option1a_FORMOSAlast_BabyMIND.mac
+#/control/execute macros/geometry_options/FPF_hall_Option1a_FORMOSAlast_CP_BabyMIND.mac
 #/control/execute macros/geometry_options/FPF_hall_Option1a_FORMOSAlast_CP.mac
 #/control/execute macros/geometry_options/FPF_hall_Option1b_FORMOSAunder.mac
 #/control/execute macros/geometry_options/FPF_hall_Option1b_FORMOSAunder_CP.mac
@@ -20,8 +21,8 @@
 
 # Initialize the chosen graphics driver
 # Use this open statement to create an OpenGL view:
-/vis/open OGLIX 1000x800-0+0
-/vis/ogl/set/displayListLimit 5000000
+#/vis/open OGLIX 1000x800-0+0
+/vis/open OGL 1000x800-0+0
 
 # For a file-based driver, use DAWN
 #/vis/open DAWNFILE

--- a/src/AnalysisManager.cc
+++ b/src/AnalysisManager.cc
@@ -165,6 +165,7 @@ void AnalysisManager::bookTrkTree() {
   trk->Branch("trackTID", &trackTID, "trackTID/I");                     
   trk->Branch("trackPID", &trackPID, "trackPID/I");                     
   trk->Branch("trackPDG", &trackPDG, "trackPDG/I");
+  trk->Branch("trackKinE", &trackKinE, "trackKinE/D");
   trk->Branch("trackNPoints", &trackNPoints, "trackNPoints/I");  
   trk->Branch("trackPointX", &trackPointX);  
   trk->Branch("trackPointY", &trackPointY);  
@@ -308,6 +309,7 @@ void AnalysisManager::BeginOfEvent() {
   trackTID = -1;                     
   trackPID = -1;     
   trackPDG = -1;
+  trackKinE = -1;
   trackNPoints = -1;  
   trackPointX.clear();  
   trackPointY.clear();  
@@ -531,6 +533,7 @@ void AnalysisManager::EndOfEvent(const G4Event* event) {
         trackTID = trajectory->GetTrackID();
         trackPID = trajectory->GetParentID();
         trackPDG = trajectory->GetPDGEncoding();
+	trackKinE = trajectory->GetInitialKineticEnergy();
         trackNPoints = trajectory->GetPointEntries();
         count_tracks++;
 	for (size_t j = 0; j < trackNPoints; ++j) {

--- a/src/AnalysisManager.cc
+++ b/src/AnalysisManager.cc
@@ -164,7 +164,7 @@ void AnalysisManager::bookTrkTree() {
   trk->Branch("evtID", &evtID, "evtID/I");
   trk->Branch("trackTID", &trackTID, "trackTID/I");                     
   trk->Branch("trackPID", &trackPID, "trackPID/I");                     
-  trk->Branch("trakcPDG", &trackPDG, "trackPDG/I");
+  trk->Branch("trackPDG", &trackPDG, "trackPDG/I");
   trk->Branch("trackNPoints", &trackNPoints, "trackNPoints/I");  
   trk->Branch("trackPointX", &trackPointX);  
   trk->Branch("trackPointY", &trackPointY);  
@@ -539,13 +539,16 @@ void AnalysisManager::EndOfEvent(const G4Event* event) {
 	  trackPointY.push_back( pos.y() );
 	  trackPointZ.push_back( pos.z() );
         }
+        trk->Fill();
+	trackPointX.clear();
+	trackPointY.clear();
+	trackPointZ.clear();
       }
     } else G4cout << "No tracks found: did you enable their storage with '/tracking/storeTrajectory 1'?" << G4endl;
     G4cout << "---> Done!" << G4endl;
   }
   
   evt->Fill();
-  trk->Fill();
 
   G4cout << "Total number of recorded hits : " << nHits << std::endl;
   if(m_saveTrack) G4cout << "Total number of recorded track: " << count_tracks << std::endl;

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -87,13 +87,17 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
 
   // FPF long paper: https://dx.doi.org/10.1088/1361-6471/ac865e
   // section 2.1.1, figure 5, and figure 7
-  G4double hallSizeX  = 8.5 * m;
-  G4double hallSizeY  = 7.2 * m;
-  G4double hallSizeZ  = 65. * m;
-  G4ThreeVector hallOffset(0., 0., hallSizeZ/2 -            // this offset accounts for the distance between 
-      GeometricalParameters::Get()->GetHallHeadDistance()); // the entrance wall of the hall and the 
-                                                            // first detector, so the first detector 
-                                                            // starts at the center of the global coordinate
+  G4double hallSizeX  = 9.4 * m;
+  G4double hallSizeY  = 7.6 * m;
+  G4double hallSizeZ  = 64.6 * m;
+  
+  // this offset accounts for: 
+  // - distance between the entrance wall of the hall and the first detector, so the first detector 
+  //   starts at the center of the global coordinate
+  // - position of the cavern center w.r.t. the line of sight, since it's not in the exact middle
+  G4ThreeVector hallOffset( GeometricalParameters::Get()->GetHallOffsetX(), 
+		            GeometricalParameters::Get()->GetHallOffsetY(), 
+			    hallSizeZ/2 - GeometricalParameters::Get()->GetHallHeadDistance()); 
                                                            
   auto hallBox = new G4Box("hallBox", hallSizeX/2, hallSizeY/2, hallSizeZ/2);
   hallLV = new G4LogicalVolume(hallBox, LArBoxMaterials->Material("Air"), "hallLV");

--- a/src/EventAction.cc
+++ b/src/EventAction.cc
@@ -46,6 +46,9 @@ void EventAction::EndOfEventAction(const G4Event* event) {
   else
     G4cout << " * No secondary tracks (excluding gamma) produced" << G4endl;
 
+  // skip AnalysisManager if there are no tracks at all!
+  if(!fNPrimaryTrack.GetValue() && !fNSecondaryTrack.GetValue() && !fNSecondaryTrackNotGamma.GetValue()) return;
+
   AnalysisManager* ana = AnalysisManager::GetInstance();
   ana->EndOfEvent(event);
 }

--- a/src/geometry/FASERnu2DetectorConstruction.cc
+++ b/src/geometry/FASERnu2DetectorConstruction.cc
@@ -88,7 +88,7 @@ void FASERnu2DetectorConstruction::BuildEmulsionTungstenModule()
 
   // build tungsten layer
   auto tungstenPlateSolid = new G4Box("tungstenPlateSolid", fEmulsionTungstenSizeX/2., fEmulsionTungstenSizeY/2., fTungstenThickness/2.);
-  fTungstenPlate = new G4LogicalVolume(tungstenPlateSolid, fMaterials->Material("Tungsten"), "tungstenPlatLogical");
+  fTungstenPlate = new G4LogicalVolume(tungstenPlateSolid, fMaterials->Material("Tungsten"), "tungstenPlateLogical");
   
   G4RotationMatrix *rot = new G4RotationMatrix();
   G4double offset = -fModuleThickness/2.;

--- a/src/geometry/GeometricalParameters.cc
+++ b/src/geometry/GeometricalParameters.cc
@@ -9,6 +9,8 @@ GeometricalParameters::GeometricalParameters()
   
   // experimental hall
   fHallHeadDistance = 3.1*m;
+  fHallOffsetX = 1.44*m;
+  fHallOffsetY = 2.21*m;
 
   // FLArE TPC volume
   fFLArETPCMaterialOption = tpcMaterialOption::LiquidArgon;


### PR DESCRIPTION
This PR addresses two issues that have come up with the background studies:
- A bug in the way the TTree storing the full particle trajectories for the event displays was being filled. Now each particle has its own array of positions allowing to plot colors differently.
- The relative position of the cavern w.r.t the background muons. All the detectors are line up on the LOS, which is (0,0) in our coordinate system. This is correct and doesn't change. However, the cavern is not actually centered on (0,0), so I'm adjusting the position of the cavern center assuming the limits of the background distributions provided correspond to the position of the cavern walls (xmax = 614cm, xmin=-326, ymin=-159, ymax=601). This places the cavern center at x=1.44m, y=2.21m from the LOS. It is very likely this is already out of date... but that's what our backgrounds were simulated with.