### PR TITLE
GDML output fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ An example macro can be found in `macros`: `backgrounds.mac`.
 |Command |Description | Default |
 |:--|:--|:--|
 |/det/saveGdml          | option for saving detector geometry in a GDML file, run before `/run/initialize`     |`false`|
+|/det/fileGdml          | option for specifying the GDML file name, run before `/run/initialize`               |`FPF_FLArE_geo.gdml`|
 |/det/checkOverlap      | check overlap of volumns during detector construction, run before `/run/initialize`  |`false`|
 |/det/addFLArE          | option for adding the FLArE detector, run before `/run/initialize`                   |`true`|
 |/det/addFORMOSA        | option for adding the FORMOSA detector, run before `/run/initialize`                 |`true`|

--- a/include/DetectorConstruction.hh
+++ b/include/DetectorConstruction.hh
@@ -27,6 +27,7 @@ class DetectorConstruction : public G4VUserDetectorConstruction {
 
     void ConstructSDandField() override;
     void SaveGDML(G4bool i) { m_saveGdml = i; }
+    void NameGDML(G4String str) { m_fileGdml = str; }
     void CheckDetOverlap(G4bool i) { fCheckOverlap = i; }
     void AddFLArE(G4bool i) { m_addFLArE = i; }
     void SetFieldValue(G4double val) { fFieldValue = val; }
@@ -45,6 +46,7 @@ class DetectorConstruction : public G4VUserDetectorConstruction {
     DetectorConstructionMessenger* messenger;
 
     G4bool m_saveGdml;
+    G4String m_fileGdml;
     G4bool fCheckOverlap;
     G4bool m_addFLArE;
     G4bool m_useBabyMIND;

--- a/include/DetectorConstructionMessenger.hh
+++ b/include/DetectorConstructionMessenger.hh
@@ -36,7 +36,8 @@ class DetectorConstructionMessenger: public G4UImessenger {
  
     // ------------------------------------
     // General /det/ commands   
-    G4UIcmdWithABool* detGdmlCmd;
+    G4UIcmdWithABool* detGdmlSaveCmd;
+    G4UIcmdWithAString* detGdmlFileCmd;
     G4UIcmdWithABool* detCheckOverlapCmd;
     G4UIcmdWithABool* detAddFLArECmd;
     G4UIcmdWithABool* detAddFORMOSACmd;

--- a/include/geometry/BabyMINDDetectorConstruction.hh
+++ b/include/geometry/BabyMINDDetectorConstruction.hh
@@ -16,7 +16,7 @@ class BabyMINDDetectorConstruction {
     ~BabyMINDDetectorConstruction();
 
     // Returns assembly volume for placement    
-    G4AssemblyVolume* GetBabyMINDAssembly(){ return fBabyMINDAssembly;}
+    G4LogicalVolume* GetBabyMINDAssembly(){ return fBabyMINDAssembly;}
   
     // Returns logical volumes
     G4LogicalVolume* GetMagnetPlate(){ return fMagnetPlate;}
@@ -32,7 +32,7 @@ class BabyMINDDetectorConstruction {
 
   private:
 
-    G4AssemblyVolume* fBabyMINDAssembly;
+    G4LogicalVolume* fBabyMINDAssembly;
     DetectorConstructionMaterial* fMaterials;
     G4LogicalVolume* fMagnetPlate;
     G4LogicalVolume* fHorizontalBar;

--- a/include/geometry/FASER2DetectorConstruction.hh
+++ b/include/geometry/FASER2DetectorConstruction.hh
@@ -1,19 +1,19 @@
-#ifndef SpectrometerMagnetConstruction_hh
-#define SpectrometerMagnetConstruction_hh
+#ifndef FASER2DetectorConstruction_hh
+#define FASER2DetectorConstruction_hh
 
 #include "G4LogicalVolume.hh"
 #include "G4AssemblyVolume.hh"
 
 #include "DetectorConstructionMaterial.hh"
 
-/// \class SpectrometerMagnetConstruction
-/// This class builds the FASER2 spectrometer magnet, using either the SAMURAI design
+/// \class FASER2DetectorConstruction
+/// This class builds the FASER2 spectrometer, using either the SAMURAI design
 /// or multiple crystal-pulling magnets from Toshiba.  
 
-class SpectrometerMagnetConstruction {
+class FASER2DetectorConstruction {
   public:
-    SpectrometerMagnetConstruction();
-    ~SpectrometerMagnetConstruction();
+    FASER2DetectorConstruction();
+    ~FASER2DetectorConstruction();
 
     // Returns assembly volume for placement    
     G4LogicalVolume* GetFASER2Assembly(){ return fFASER2Assembly;}

--- a/include/geometry/FASERnu2DetectorConstruction.hh
+++ b/include/geometry/FASERnu2DetectorConstruction.hh
@@ -16,7 +16,7 @@ class FASERnu2DetectorConstruction {
     ~FASERnu2DetectorConstruction();
 
     // Returns assembly volume for placement    
-    G4AssemblyVolume* GetFASERnu2Assembly(){ return fFASERnu2Assembly;}
+    G4LogicalVolume* GetFASERnu2Assembly(){ return fFASERnu2Assembly;}
   
     // Returns logical volumes
     G4LogicalVolume* GetEmulsionFilm(){ return fEmulsionFilm;}
@@ -28,7 +28,7 @@ class FASERnu2DetectorConstruction {
 
   private:
 
-    G4AssemblyVolume* fFASERnu2Assembly;
+    G4LogicalVolume* fFASERnu2Assembly;
     DetectorConstructionMaterial* fMaterials;
     G4LogicalVolume* fEmulsionFilm;
     G4LogicalVolume* fTungstenPlate;

--- a/include/geometry/FLArEHadCatcherMuonFinderConstruction.hh
+++ b/include/geometry/FLArEHadCatcherMuonFinderConstruction.hh
@@ -16,7 +16,7 @@ class FLArEHadCatcherMuonFinderConstruction {
     ~FLArEHadCatcherMuonFinderConstruction();
 
     // Return assembly volume for placement
-    G4AssemblyVolume* GetHadCatcherMuonFinderAssembly() { return fHadCatcherMuonFinderAssembly; }
+    G4LogicalVolume* GetHadCatcherMuonFinderAssembly() { return fHadCatcherMuonFinderAssembly; }
 
     // Return logical volumes
     // Hadronic calorimetry
@@ -35,7 +35,7 @@ class FLArEHadCatcherMuonFinderConstruction {
   private:
     DetectorConstructionMaterial* fMaterials;
   
-    G4AssemblyVolume* fHadCatcherMuonFinderAssembly;
+    G4LogicalVolume* fHadCatcherMuonFinderAssembly;
 
     G4LogicalVolume* HadAbsorLayersLogical;
     G4LogicalVolume* HadCalXCellLogical;

--- a/include/geometry/FLArETPCDetectorConstruction.hh
+++ b/include/geometry/FLArETPCDetectorConstruction.hh
@@ -16,7 +16,7 @@ class FLArETPCDetectorConstruction {
     ~FLArETPCDetectorConstruction();
 
     // Return assembly volume for placement
-    G4AssemblyVolume* GetFLArETPCAssembly() { return fFLArETPCAssembly; }
+    G4LogicalVolume* GetFLArETPCAssembly() { return fFLArETPCAssembly; }
 
     // Return logical volumes
     // TPC volume
@@ -30,7 +30,7 @@ class FLArETPCDetectorConstruction {
     DetectorConstructionMaterial* fMaterials;
     G4Material* detectorMaterial;
 
-    G4AssemblyVolume* fFLArETPCAssembly;
+    G4LogicalVolume* fFLArETPCAssembly;
 
     G4LogicalVolume* fFLArETPCLog;
     G4LogicalVolume* lArBoxLog;

--- a/include/geometry/FORMOSADetectorConstruction.hh
+++ b/include/geometry/FORMOSADetectorConstruction.hh
@@ -16,7 +16,7 @@ class FORMOSADetectorConstruction {
     ~FORMOSADetectorConstruction();
 
     // Returns assembly volume for placement    
-    G4AssemblyVolume* GetFORMOSAAssembly(){ return fFORMOSAAssembly;}
+    G4LogicalVolume* GetFORMOSAAssembly(){ return fFORMOSAAssembly;}
   
     // Returns logical volumes
     G4LogicalVolume* GetScintillatorBar(){ return fScintillatorBar;}
@@ -27,7 +27,7 @@ class FORMOSADetectorConstruction {
 
   private:
 
-    G4AssemblyVolume* fFORMOSAAssembly;
+    G4LogicalVolume* fFORMOSAAssembly;
     DetectorConstructionMaterial* fMaterials;
     G4LogicalVolume* fScintillatorBar;
     G4AssemblyVolume* fScintillatorAssembly;

--- a/include/geometry/GeometricalParameters.hh
+++ b/include/geometry/GeometricalParameters.hh
@@ -93,10 +93,10 @@ class GeometricalParameters  {
     // FASER2 Spectrometer Magnet
     enum magnetOption{ SAMURAI, CrystalPulling, unknown};
     magnetOption ConvertStringToMagnetOption(G4String val);
-    void SetSpectrometerMagnetOption(magnetOption val) { fSpectrometerMagnetOption = val; }
-    magnetOption GetSpectrometerMagnetOption() { return fSpectrometerMagnetOption; }
-    void SetSpectrometerMagnetField(G4double val) { fSpectrometerMagnetField = val; }
-    G4ThreeVector GetSpectrometerMagnetField();
+    void SetFASER2MagnetOption(magnetOption val) { fFASER2MagnetOption = val; }
+    magnetOption GetFASER2MagnetOption() { return fFASER2MagnetOption; }
+    void SetFASER2MagnetField(G4double val) { fFASER2MagnetField = val; }
+    G4ThreeVector GetFASER2MagnetField();
     void SetMagnetTotalSizeZ(G4double val) { fMagnetTotalSizeZ = val; }
     G4double GetMagnetTotalSizeZ() { return fMagnetTotalSizeZ; }
     void SetTrackingStationTotalSizeZ(G4double val) { fTrackingStationTotalSizeZ = val; }
@@ -106,29 +106,29 @@ class GeometricalParameters  {
     void SetFASER2TotalSizeZ(G4double val) { fFASER2TotalSizeZ = val; }
     G4double GetFASER2TotalSizeZ() { return fFASER2TotalSizeZ; }
     // SAMURAI design
-    void SetSpectrometerMagnetWindowX(G4double val) { fSpectrometerMagnetWindowX = val; }
-    G4double GetSpectrometerMagnetWindowX() { return fSpectrometerMagnetWindowX; }
-    void SetSpectrometerMagnetWindowY(G4double val) { fSpectrometerMagnetWindowY = val; }
-    G4double GetSpectrometerMagnetWindowY() { return fSpectrometerMagnetWindowY; }
-    void SetSpectrometerMagnetWindowZ(G4double val) { fSpectrometerMagnetWindowZ = val; }
-    G4double GetSpectrometerMagnetWindowZ() { return fSpectrometerMagnetWindowZ; }
-    void SetSpectrometerMagnetYokeThickX(G4double val) { fSpectrometerMagnetYokeThickX = val; }
-    G4double GetSpectrometerMagnetYokeThickX() { return fSpectrometerMagnetYokeThickX; }
-    void SetSpectrometerMagnetYokeThickY(G4double val) { fSpectrometerMagnetYokeThickY = val; }
-    G4double GetSpectrometerMagnetYokeThickY() { return fSpectrometerMagnetYokeThickY; }
+    void SetFASER2MagnetWindowX(G4double val) { fFASER2MagnetWindowX = val; }
+    G4double GetFASER2MagnetWindowX() { return fFASER2MagnetWindowX; }
+    void SetFASER2MagnetWindowY(G4double val) { fFASER2MagnetWindowY = val; }
+    G4double GetFASER2MagnetWindowY() { return fFASER2MagnetWindowY; }
+    void SetFASER2MagnetWindowZ(G4double val) { fFASER2MagnetWindowZ = val; }
+    G4double GetFASER2MagnetWindowZ() { return fFASER2MagnetWindowZ; }
+    void SetFASER2MagnetYokeThickX(G4double val) { fFASER2MagnetYokeThickX = val; }
+    G4double GetFASER2MagnetYokeThickX() { return fFASER2MagnetYokeThickX; }
+    void SetFASER2MagnetYokeThickY(G4double val) { fFASER2MagnetYokeThickY = val; }
+    G4double GetFASER2MagnetYokeThickY() { return fFASER2MagnetYokeThickY; }
     // Crystal-Pulling design
-    void SetSpectrometerMagnetInnerR(G4double val) { fSpectrometerMagnetInnerR = val; }
-    G4double GetSpectrometerMagnetInnerR() { return fSpectrometerMagnetInnerR; }
-    void SetSpectrometerMagnetOuterR(G4double val) { fSpectrometerMagnetOuterR = val; }
-    G4double GetSpectrometerMagnetOuterR() { return fSpectrometerMagnetOuterR; }
-    void SetSpectrometerMagnetLengthZ(G4double val) { fSpectrometerMagnetLengthZ = val; }
-    G4double GetSpectrometerMagnetLengthZ() { return fSpectrometerMagnetLengthZ; }
-    void SetNSpectrometerMagnets(G4int val) { fNSpectrometerMagnets = val; }
-    G4int GetNSpectrometerMagnets() { return fNSpectrometerMagnets; }
-    void SetSpectrometerMagnetGap(G4double val) { fSpectrometerMagnetGap = val; }
-    G4double GetSpectrometerMagnetGap() { return fSpectrometerMagnetGap; }  
-    void SetSpectrometerMagnetSpacing(G4double val) { fSpectrometerMagnetSpacing = val; }
-    G4double GetSpectrometerMagnetSpacing() { return fSpectrometerMagnetSpacing; }  
+    void SetFASER2MagnetInnerR(G4double val) { fFASER2MagnetInnerR = val; }
+    G4double GetFASER2MagnetInnerR() { return fFASER2MagnetInnerR; }
+    void SetFASER2MagnetOuterR(G4double val) { fFASER2MagnetOuterR = val; }
+    G4double GetFASER2MagnetOuterR() { return fFASER2MagnetOuterR; }
+    void SetFASER2MagnetLengthZ(G4double val) { fFASER2MagnetLengthZ = val; }
+    G4double GetFASER2MagnetLengthZ() { return fFASER2MagnetLengthZ; }
+    void SetNFASER2Magnets(G4int val) { fNFASER2Magnets = val; }
+    G4int GetNFASER2Magnets() { return fNFASER2Magnets; }
+    void SetFASER2MagnetGap(G4double val) { fFASER2MagnetGap = val; }
+    G4double GetFASER2MagnetGap() { return fFASER2MagnetGap; }  
+    void SetFASER2MagnetSpacing(G4double val) { fFASER2MagnetSpacing = val; }
+    G4double GetFASER2MagnetSpacing() { return fFASER2MagnetSpacing; }  
     // Tracking station
     void SetNTrackingStations(G4int val) { fNTrackingStations = val; }
     G4int GetNTrackingStations() { return fNTrackingStations; }  
@@ -240,25 +240,25 @@ class GeometricalParameters  {
     G4String fBabyMINDBlockSequence;
 
     // FASER2 Spectrometer Magnet
-    magnetOption fSpectrometerMagnetOption;
-    G4double fSpectrometerMagnetField;
+    magnetOption fFASER2MagnetOption;
+    G4double fFASER2MagnetField;
     G4double fMagnetTotalSizeZ;
     G4double fTrackingStationTotalSizeZ;
     G4double fMagnetZPos;
     G4double fFASER2TotalSizeZ;
     // SAMURAI design
-    G4double fSpectrometerMagnetWindowX;
-    G4double fSpectrometerMagnetWindowY;
-    G4double fSpectrometerMagnetWindowZ;
-    G4double fSpectrometerMagnetYokeThickX;
-    G4double fSpectrometerMagnetYokeThickY;
+    G4double fFASER2MagnetWindowX;
+    G4double fFASER2MagnetWindowY;
+    G4double fFASER2MagnetWindowZ;
+    G4double fFASER2MagnetYokeThickX;
+    G4double fFASER2MagnetYokeThickY;
     // Crystal-Pulling design
-    G4double fSpectrometerMagnetInnerR;
-    G4double fSpectrometerMagnetOuterR;
-    G4double fSpectrometerMagnetLengthZ;
-    G4int fNSpectrometerMagnets;
-    G4double fSpectrometerMagnetGap;
-    G4double fSpectrometerMagnetSpacing;
+    G4double fFASER2MagnetInnerR;
+    G4double fFASER2MagnetOuterR;
+    G4double fFASER2MagnetLengthZ;
+    G4int fNFASER2Magnets;
+    G4double fFASER2MagnetGap;
+    G4double fFASER2MagnetSpacing;
     // Tracking stations
     G4int fNTrackingStations;
     G4int fNScintillatorBarsY;

--- a/include/geometry/SpectrometerMagnetConstruction.hh
+++ b/include/geometry/SpectrometerMagnetConstruction.hh
@@ -16,7 +16,7 @@ class SpectrometerMagnetConstruction {
     ~SpectrometerMagnetConstruction();
 
     // Returns assembly volume for placement    
-    G4AssemblyVolume* GetSpectrometerMagnetAssembly(){ return fMagnetAssembly;}
+    G4LogicalVolume* GetFASER2Assembly(){ return fFASER2Assembly;}
   
     // Returns logical volumes
     G4LogicalVolume* GetMagneticVolume(){ return fMagnetWindow;}
@@ -30,7 +30,7 @@ class SpectrometerMagnetConstruction {
 
   private:
 
-    G4AssemblyVolume* fMagnetAssembly;
+    G4LogicalVolume* fFASER2Assembly;
     DetectorConstructionMaterial* fMaterials;
     G4LogicalVolume* fMagnetYoke;
     G4LogicalVolume* fMagnetWindow;

--- a/macros/geometry_options/FLArE_FASER2_only.mac
+++ b/macros/geometry_options/FLArE_FASER2_only.mac
@@ -3,6 +3,8 @@
 # - FLArE (TPC + HadCather + MuonFinder)
 # - FASER2 (SAMURAI magnet)
 
+/det/fileGdml FLArE_FASER2_only.gdml
+
 # Configuring FLArE
 /det/addFLArE true
 /det/flare/addFLArEPos 0 0 4300 mm

--- a/macros/geometry_options/FLArE_only.mac
+++ b/macros/geometry_options/FLArE_only.mac
@@ -1,6 +1,8 @@
 # This file defines the standard configuration for the FLArE only option
 # The geometry contains only FLArE (TPC + HadCather + MuonFinder)
 
+/det/fileGdml FLArE_only.gdml
+
 # Configuring FLArE
 /det/addFLArE true
 /det/flare/addFLArEPos 0 0 4300 mm

--- a/macros/geometry_options/FLArE_only_BabyMIND.mac
+++ b/macros/geometry_options/FLArE_only_BabyMIND.mac
@@ -1,6 +1,8 @@
 # This file defines the standard configuration for the FLArE only option
 # The geometry contains only FLArE (TPC + BabyMIND)
 
+/det/fileGdml FLArE_only_BabyMIND.gdml
+
 # Configuring FLArE
 /det/addFLArE true
 /det/flare/addFLArEPos 0 0 4300 mm

--- a/macros/geometry_options/FPF_hall_Option1a_FORMOSAlast.mac
+++ b/macros/geometry_options/FPF_hall_Option1a_FORMOSAlast.mac
@@ -6,6 +6,8 @@
 # - FASER2 (SAMURAI magnet)
 # - FORMOSA
 
+/det/fileGdml FPF_hall_Option1a_FORMOSAlast.gdml
+
 # Configuring FLArE
 /det/addFLArE true
 /det/flare/addFLArEPos 0 0 4300 mm

--- a/macros/geometry_options/FPF_hall_Option1a_FORMOSAlast_BabyMIND.mac
+++ b/macros/geometry_options/FPF_hall_Option1a_FORMOSAlast_BabyMIND.mac
@@ -6,6 +6,8 @@
 # - FASER2 (SAMURAI magnet)
 # - FORMOSA
 
+/det/fileGdml FPF_hall_Option1a_FORMOSAlast_BabyMIND.gdml
+
 # Configuring FLArE
 /det/addFLArE true
 /det/flare/addFLArEPos 0 0 4300 mm

--- a/macros/geometry_options/FPF_hall_Option1a_FORMOSAlast_CP.mac
+++ b/macros/geometry_options/FPF_hall_Option1a_FORMOSAlast_CP.mac
@@ -7,6 +7,8 @@
 # - FASER2 (CrystalPulling magnets)
 # - FORMOSA
 
+/det/fileGdml FPF_hall_Option1a_FORMOSAlast_CP.gdml
+
 # Configuring FLArE
 /det/addFLArE true
 /det/flare/addFLArEPos 0 0 4300 mm

--- a/macros/geometry_options/FPF_hall_Option1a_FORMOSAlast_CP_BabyMIND.mac
+++ b/macros/geometry_options/FPF_hall_Option1a_FORMOSAlast_CP_BabyMIND.mac
@@ -7,6 +7,8 @@
 # - FASER2 (CrystalPulling magnets)
 # - FORMOSA
 
+/det/fileGdml FPF_hall_Option1a_FORMOSAlast_CP_BabyMIND.gdml
+
 # Configuring FLArE
 /det/addFLArE true
 /det/flare/addFLArEPos 0 0 4300 mm

--- a/macros/geometry_options/FPF_hall_Option1b_FORMOSAunder.mac
+++ b/macros/geometry_options/FPF_hall_Option1b_FORMOSAunder.mac
@@ -6,6 +6,8 @@
 # - FORMOSA (under LOS)
 # - FASER2 (SAMURAI magnet)
 
+/det/fileGdml FPF_hall_Option1b_FORMOSAunder.gdml
+
 # Configuring FLArE
 /det/addFLArE true
 /det/flare/addFLArEPos 0 0 4300 mm

--- a/macros/geometry_options/FPF_hall_Option1b_FORMOSAunder_CP.mac
+++ b/macros/geometry_options/FPF_hall_Option1b_FORMOSAunder_CP.mac
@@ -7,6 +7,8 @@
 # - FORMOSA (under LOS)
 # - FASER2 (CrystalPulling magnets)
 
+/det/fileGdml FPF_hall_Option1b_FORMOSAunder_CP.gdml
+
 # Configuring FLArE
 /det/addFLArE true
 /det/flare/addFLArEPos 0 0 4300 mm

--- a/macros/geometry_options/FPF_hall_Option2_FASERnufirst.mac
+++ b/macros/geometry_options/FPF_hall_Option2_FASERnufirst.mac
@@ -7,6 +7,8 @@
 # - FORMOSA (under LOS)
 # - FASER2 (SAMURAI magnet)
 
+/det/fileGdml FPF_hall_Option2_FASERnufirst.gdml
+
 # Configuring FASERnu2
 /det/addFASERnu2 true
 /det/fasernu/addFASERnu2Pos 0 0 4293 mm

--- a/macros/geometry_options/FPF_hall_Option2_FASERnufirst_CP.mac
+++ b/macros/geometry_options/FPF_hall_Option2_FASERnufirst_CP.mac
@@ -8,6 +8,8 @@
 # - FORMOSA (under LOS)
 # - FASER2 (CrystalPulling magnet)
 
+/det/fileGdml FPF_hall_Option2_FASERnufirst_CP.gdml
+
 # Configuring FASERnu2
 /det/addFASERnu2 true
 /det/fasernu/addFASERnu2Pos 0 0 4293 mm

--- a/macros/geometry_options/FPF_hall_Reference.mac
+++ b/macros/geometry_options/FPF_hall_Reference.mac
@@ -5,6 +5,8 @@
 # - FASERnu2
 # - FASER2 (SAMURAI magnet)
 
+/det/fileGdml FPF_hall_Reference.gdml
+
 # Configuring FLArE
 /det/addFLArE true
 /det/flare/addFLArEPos 0 0 4300 mm

--- a/macros/geometry_options/FPF_hall_Reference_CP.mac
+++ b/macros/geometry_options/FPF_hall_Reference_CP.mac
@@ -6,6 +6,8 @@
 # - FASERnu2
 # - FASER2 (CrystalPulling magnets)
 
+/det/fileGdml FPF_hall_Reference_CP.gdml
+
 # Configuring FLArE
 /det/addFLArE true
 /det/flare/addFLArEPos 0 0 4300 mm

--- a/src/AnalysisManager.cc
+++ b/src/AnalysisManager.cc
@@ -493,8 +493,8 @@ void AnalysisManager::EndOfEvent(const G4Event* event) {
     // apply circular fitting for FASER2 spectrometer magnet
     if( trkNhits > 0 ){
       
-      Nmagnets = (GeometricalParameters::Get()->GetSpectrometerMagnetOption() == GeometricalParameters::magnetOption::SAMURAI) ? 1 :
-                  GeometricalParameters::Get()->GetNSpectrometerMagnets();
+      Nmagnets = (GeometricalParameters::Get()->GetFASER2MagnetOption() == GeometricalParameters::magnetOption::SAMURAI) ? 1 :
+                  GeometricalParameters::Get()->GetNFASER2Magnets();
       G4cout << "Number of FASER2 magnets: " << Nmagnets << G4endl;
 
       circularfitter::CircleExtractor* circExtract = new circularfitter::CircleExtractor(trkXFSL,trkYFSL,trkZFSL);

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -53,6 +53,7 @@ DetectorConstruction::DetectorConstruction()
   DefineMaterial();
   messenger = new DetectorConstructionMessenger(this);
   m_saveGdml = false;
+  m_fileGdml = "FPF_FLArE_geo.gdml";
   fCheckOverlap = false;
 }
 
@@ -241,7 +242,8 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
 
   if (m_saveGdml) {
     G4GDMLParser fParser;
-    fParser.Write("FPF_FLArE_Geo.gdml", worldPV);
+    G4cout << "Exporting geometry to " << m_fileGdml << G4endl;
+    fParser.Write(m_fileGdml, worldPV);
   }
 
   return worldPV;

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -144,8 +144,8 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
     
       G4double babyMINDLengthZ  = GeometricalParameters::Get()->GetBabyMINDTotalSizeZ();
       G4ThreeVector babyMINDPos = GeometricalParameters::Get()->GetFLArEPosition() +
-	                          G4ThreeVector(0.,0.,lArSizeZ/2.+TPCInsulationThickness) +
-				  G4ThreeVector(0.,0.,babyMINDLengthZ/2.);
+	                                G4ThreeVector(0.,0.,lArSizeZ/2.+TPCInsulationThickness) +
+				                          G4ThreeVector(0.,0.,babyMINDLengthZ/2.);
       babyMINDPos -= hallOffset;
       new G4PVPlacement(nullptr, babyMINDPos, BabyMINDAssembly, "BabyMINDPhysical", hallLV, false, 0, fCheckOverlap);
       
@@ -170,7 +170,7 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
       G4double HadCatMuonFindLengthZ  = HadCatcherLength + MuonFinderLength;
       G4ThreeVector HadCatMuonFindPos = GeometricalParameters::Get()->GetFLArEPosition() +
 	                                G4ThreeVector(0.,0.,lArSizeZ/2.+TPCInsulationThickness) +
-				        G4ThreeVector(0.,0.,HadCatMuonFindLengthZ/2.);
+				                          G4ThreeVector(0.,0.,HadCatMuonFindLengthZ/2.);
     
       HadCatMuonFindPos -= hallOffset;
       HadCatMuonFindAssembly->MakeImprint(hallLV, HadCatMuonFindPos, nullptr, 0, fCheckOverlap);
@@ -205,13 +205,13 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
     FASERnu2DetectorConstruction *FASERnu2Assembler = new FASERnu2DetectorConstruction();
     FASERnu2EmulsionLogical = FASERnu2Assembler->GetEmulsionFilm();
     FASERnu2VetoInterfaceLogical = FASERnu2Assembler->GetVetoInterfaceDetector();
-    G4AssemblyVolume* FASERnu2Assembly = FASERnu2Assembler->GetFASERnu2Assembly();
+    G4LogicalVolume* FASERnu2Assembly = FASERnu2Assembler->GetFASERnu2Assembly();
     
     // positioning
     G4double lengthFASERnu2 = GeometricalParameters::Get()->GetFASERnu2TotalSizeZ();
     G4ThreeVector FASERnu2Pos = GeometricalParameters::Get()->GetFASERnu2Position();
     FASERnu2Pos -= hallOffset;
-    FASERnu2Assembly->MakeImprint(hallLV, FASERnu2Pos, nullptr, 0, fCheckOverlap);
+    new G4PVPlacement(nullptr, FASERnu2Pos, FASERnu2Assembly, "FASERnu2Physical", hallLV, false, 0, fCheckOverlap);
 
     G4cout<<"Length of FASERnu2 : "<<lengthFASERnu2<<G4endl;
     G4cout<<"Center of FASERnu2 : "<<FASERnu2Pos+hallOffset<<G4endl; // w.r.t the global coordinate

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -136,7 +136,7 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
     if( m_useBabyMIND ){   /// use BabyMIND
   
       BabyMINDDetectorConstruction *BabyMINDAssembler = new BabyMINDDetectorConstruction();
-      G4AssemblyVolume *BabyMINDAssembly = BabyMINDAssembler->GetBabyMINDAssembly();
+      G4LogicalVolume *BabyMINDAssembly = BabyMINDAssembler->GetBabyMINDAssembly();
   
       BabyMINDMagnetPlateLogical = BabyMINDAssembler->GetMagnetPlate();
       BabyMINDVerticalBar = BabyMINDAssembler->GetVerticalBar();
@@ -147,7 +147,7 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
 	                          G4ThreeVector(0.,0.,lArSizeZ/2.+TPCInsulationThickness) +
 				  G4ThreeVector(0.,0.,babyMINDLengthZ/2.);
       babyMINDPos -= hallOffset;
-      BabyMINDAssembly->MakeImprint(hallLV, babyMINDPos, nullptr, 0, fCheckOverlap);
+      new G4PVPlacement(nullptr, babyMINDPos, BabyMINDAssembly, "BabyMINDPhysical", hallLV, false, 0, fCheckOverlap);
       
       G4cout << "Length of BabyMIND : " << babyMINDLengthZ << G4endl;
       G4cout << "Center of BabyMIND : " << babyMINDPos+hallOffset << G4endl; // w.r.t the global coordinate

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -241,7 +241,7 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
 
   if (m_saveGdml) {
     G4GDMLParser fParser;
-    fParser.Write("LArBoxDetGeo.gdml", worldPV);
+    fParser.Write("FPF_FLArE_Geo.gdml", worldPV);
   }
 
   return worldPV;

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -92,8 +92,8 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
   //   starts at the center of the global coordinate
   // - position of the cavern center w.r.t. the line of sight, since it's not in the exact middle
   G4ThreeVector hallOffset( GeometricalParameters::Get()->GetHallOffsetX(), 
-		                        GeometricalParameters::Get()->GetHallOffsetY(), 
-			                      hallSizeZ/2 - GeometricalParameters::Get()->GetHallHeadDistance()); 
+                            GeometricalParameters::Get()->GetHallOffsetY(), 
+                            hallSizeZ/2 - GeometricalParameters::Get()->GetHallHeadDistance()); 
                                                            
   auto hallBox = new G4Box("hallBox", hallSizeX/2, hallSizeY/2, hallSizeZ/2);
   hallLV = new G4LogicalVolume(hallBox, LArBoxMaterials->Material("Air"), "hallLV");
@@ -133,8 +133,8 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
     
       G4double babyMINDLengthZ  = GeometricalParameters::Get()->GetBabyMINDTotalSizeZ();
       G4ThreeVector babyMINDPos = GeometricalParameters::Get()->GetFLArEPosition() +
-	                                G4ThreeVector(0.,0.,lArSizeZ/2.+TPCInsulationThickness) +
-				                          G4ThreeVector(0.,0.,babyMINDLengthZ/2.);
+                                  G4ThreeVector(0.,0.,lArSizeZ/2.+TPCInsulationThickness) +
+                                  G4ThreeVector(0.,0.,babyMINDLengthZ/2.);
       babyMINDPos -= hallOffset;
       new G4PVPlacement(nullptr, babyMINDPos, BabyMINDAssembly, "BabyMINDPhysical", hallLV, false, 0, fCheckOverlap);
       

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -3,7 +3,7 @@
 #include "DetectorConstructionMessenger.hh"
 #include "LArBoxSD.hh"
 
-#include "geometry/SpectrometerMagnetConstruction.hh"
+#include "geometry/FASER2DetectorConstruction.hh"
 #include "geometry/GeometricalParameters.hh"
 #include "geometry/FASERnu2DetectorConstruction.hh"
 #include "geometry/FORMOSADetectorConstruction.hh"
@@ -210,7 +210,7 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
   // FASER2 Magnet + Tracking stations
 
   if (m_addFASER2) {
-    SpectrometerMagnetConstruction *magnetAssembler = new SpectrometerMagnetConstruction();
+    FASER2DetectorConstruction *magnetAssembler = new FASER2DetectorConstruction();
     FASER2MagnetLogical = magnetAssembler->GetMagneticVolume(); //need to assign B field
     TrackingVerScinBarLogical = magnetAssembler->GetVerTrackingScinBar(); //need to assign SD
     TrackingHorScinBarLogical = magnetAssembler->GetHorTrackingScinBar(); //need to assign SD
@@ -371,7 +371,7 @@ void DetectorConstruction::ConstructSDandField() {
     SDIdx++;
 
     // FASER2 magnetic field
-    G4ThreeVector fieldValueFASER2 = GeometricalParameters::Get()->GetSpectrometerMagnetField();
+    G4ThreeVector fieldValueFASER2 = GeometricalParameters::Get()->GetFASER2MagnetField();
     magFieldFASER2 = new G4UniformMagField(fieldValueFASER2);
     fieldMgrFASER2 = new G4FieldManager();
     fieldMgrFASER2->SetDetectorField(magFieldFASER2);

--- a/src/DetectorConstructionMessenger.cc
+++ b/src/DetectorConstructionMessenger.cc
@@ -361,29 +361,29 @@ void DetectorConstructionMessenger::SetNewValue(G4UIcommand* command, G4String n
   else if (command == faserPosCmd) 
     GeometricalParameters::Get()->SetFASER2Position(faserPosCmd->GetNew3VectorValue(newValues));
   else if (command == faserMagnetGeomCmd)  
-    GeometricalParameters::Get()->SetSpectrometerMagnetOption(GeometricalParameters::Get()->ConvertStringToMagnetOption(newValues));
+    GeometricalParameters::Get()->SetFASER2MagnetOption(GeometricalParameters::Get()->ConvertStringToMagnetOption(newValues));
   else if (command == faserMagnetFieldCmd) 
-    GeometricalParameters::Get()->SetSpectrometerMagnetField(faserMagnetFieldCmd->ConvertToDimensionedDouble(newValues));
+    GeometricalParameters::Get()->SetFASER2MagnetField(faserMagnetFieldCmd->ConvertToDimensionedDouble(newValues));
   else if (command == faserMagnetWinXCmd) 
-    GeometricalParameters::Get()->SetSpectrometerMagnetWindowX(faserMagnetWinXCmd->ConvertToDimensionedDouble(newValues));
+    GeometricalParameters::Get()->SetFASER2MagnetWindowX(faserMagnetWinXCmd->ConvertToDimensionedDouble(newValues));
   else if (command == faserMagnetWinYCmd) 
-    GeometricalParameters::Get()->SetSpectrometerMagnetWindowY(faserMagnetWinYCmd->ConvertToDimensionedDouble(newValues));
+    GeometricalParameters::Get()->SetFASER2MagnetWindowY(faserMagnetWinYCmd->ConvertToDimensionedDouble(newValues));
   else if (command == faserMagnetWinZCmd) 
-    GeometricalParameters::Get()->SetSpectrometerMagnetWindowZ(faserMagnetWinZCmd->ConvertToDimensionedDouble(newValues));
+    GeometricalParameters::Get()->SetFASER2MagnetWindowZ(faserMagnetWinZCmd->ConvertToDimensionedDouble(newValues));
   else if (command == faserYokeThickXCmd) 
-    GeometricalParameters::Get()->SetSpectrometerMagnetYokeThickX(faserYokeThickXCmd->ConvertToDimensionedDouble(newValues));
+    GeometricalParameters::Get()->SetFASER2MagnetYokeThickX(faserYokeThickXCmd->ConvertToDimensionedDouble(newValues));
   else if (command == faserYokeThickYCmd) 
-    GeometricalParameters::Get()->SetSpectrometerMagnetYokeThickY(faserYokeThickYCmd->ConvertToDimensionedDouble(newValues));
+    GeometricalParameters::Get()->SetFASER2MagnetYokeThickY(faserYokeThickYCmd->ConvertToDimensionedDouble(newValues));
   else if (command == faserMagnetInnerRCmd) 
-    GeometricalParameters::Get()->SetSpectrometerMagnetInnerR(faserMagnetInnerRCmd->ConvertToDimensionedDouble(newValues));
+    GeometricalParameters::Get()->SetFASER2MagnetInnerR(faserMagnetInnerRCmd->ConvertToDimensionedDouble(newValues));
   else if (command == faserMagnetOuterRCmd) 
-    GeometricalParameters::Get()->SetSpectrometerMagnetOuterR(faserMagnetOuterRCmd->ConvertToDimensionedDouble(newValues));
+    GeometricalParameters::Get()->SetFASER2MagnetOuterR(faserMagnetOuterRCmd->ConvertToDimensionedDouble(newValues));
   else if (command == faserMagnetLengthZCmd) 
-    GeometricalParameters::Get()->SetSpectrometerMagnetLengthZ(faserMagnetLengthZCmd->ConvertToDimensionedDouble(newValues));
+    GeometricalParameters::Get()->SetFASER2MagnetLengthZ(faserMagnetLengthZCmd->ConvertToDimensionedDouble(newValues));
   else if (command == faserMagnetGapCmd) 
-    GeometricalParameters::Get()->SetSpectrometerMagnetGap(faserMagnetGapCmd->ConvertToDimensionedDouble(newValues));
+    GeometricalParameters::Get()->SetFASER2MagnetGap(faserMagnetGapCmd->ConvertToDimensionedDouble(newValues));
   else if (command == faserMagnetNumberCmd) 
-    GeometricalParameters::Get()->SetNSpectrometerMagnets(faserMagnetNumberCmd->GetNewIntValue(newValues));
+    GeometricalParameters::Get()->SetNFASER2Magnets(faserMagnetNumberCmd->GetNewIntValue(newValues));
   //faser2 tracking stations
   else if (command == faserTrackingNumberCmd) 
     GeometricalParameters::Get()->SetNTrackingStations(faserTrackingNumberCmd->GetNewIntValue(newValues));

--- a/src/DetectorConstructionMessenger.cc
+++ b/src/DetectorConstructionMessenger.cc
@@ -22,9 +22,12 @@ DetectorConstructionMessenger::DetectorConstructionMessenger(DetectorConstructio
     detDir->SetGuidance("Detector control");
     
     // saving gdml
-    detGdmlCmd = new G4UIcmdWithABool("/det/saveGdml", this);
-    detGdmlCmd->SetParameterName("saveGdml", true);
-    detGdmlCmd->SetDefaultValue(false);
+    detGdmlSaveCmd = new G4UIcmdWithABool("/det/saveGdml", this);
+    detGdmlSaveCmd->SetParameterName("saveGdml", true);
+    detGdmlSaveCmd->SetDefaultValue(false);
+    detGdmlFileCmd = new G4UIcmdWithAString("/det/fileGdml", this);
+    detGdmlFileCmd->SetGuidance("set filename for GDML output");
+
     // check overlap
     detCheckOverlapCmd = new G4UIcmdWithABool("/det/checkOverlap", this);
     detCheckOverlapCmd->SetParameterName("checkOverlap", true);
@@ -219,7 +222,8 @@ DetectorConstructionMessenger::DetectorConstructionMessenger(DetectorConstructio
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 DetectorConstructionMessenger::~DetectorConstructionMessenger() {
-  delete detGdmlCmd;
+  delete detGdmlSaveCmd;
+  delete detGdmlFileCmd;
   delete detCheckOverlapCmd;
   delete detAddFLArECmd;
   delete detAddFORMOSACmd;
@@ -288,7 +292,8 @@ DetectorConstructionMessenger::~DetectorConstructionMessenger() {
 void DetectorConstructionMessenger::SetNewValue(G4UIcommand* command, G4String newValues) {
  
   // GENERAL COMMANDS
-  if (command == detGdmlCmd) det->SaveGDML(detGdmlCmd->GetNewBoolValue(newValues));
+  if (command == detGdmlSaveCmd) det->SaveGDML(detGdmlSaveCmd->GetNewBoolValue(newValues));
+  else if (command == detGdmlFileCmd) det->NameGDML(newValues);
   else if (command == detCheckOverlapCmd) det->CheckDetOverlap(detCheckOverlapCmd->GetNewBoolValue(newValues));
   else if (command == detAddFLArECmd) det->AddFLArE(detAddFLArECmd->GetNewBoolValue(newValues)); 
   else if (command == detAddFORMOSACmd) det->AddFORMOSA(detAddFORMOSACmd->GetNewBoolValue(newValues));

--- a/src/geometry/BabyMINDDetectorConstruction.cc
+++ b/src/geometry/BabyMINDDetectorConstruction.cc
@@ -62,6 +62,7 @@ BabyMINDDetectorConstruction::BabyMINDDetectorConstruction()
   // starting position for placement
   G4ThreeVector prevPos(0.,0.,-BabyMINDTotalSizeZ/2.);
   char prev = 'i';
+  int k = 0;
 
   for(auto c : fBlockSequence) {
     
@@ -88,7 +89,8 @@ BabyMINDDetectorConstruction::BabyMINDDetectorConstruction()
         shift += fMagnetPlateThickness/2.;
         currentPos += G4ThreeVector(0.,0.,shift);
         // placing a magnet module
-        new G4PVPlacement(noRot, currentPos, fMagnetPlate, "MagnetPlatePhysical", fBabyMINDLogical, false, 0, false);
+        new G4PVPlacement(noRot, currentPos, fMagnetPlate, "MagnetPlatePhysical", fBabyMINDAssembly, false, k, false);
+        k++;
         // update pointer to the end of the module
         // shift by only remaining half size
         shift = fMagnetPlateThickness/2.;

--- a/src/geometry/BabyMINDDetectorConstruction.cc
+++ b/src/geometry/BabyMINDDetectorConstruction.cc
@@ -45,15 +45,19 @@ BabyMINDDetectorConstruction::BabyMINDDetectorConstruction()
   BuildMagnetModule();
   BuildScintillatorModule(); 
  
-  fBabyMINDAssembly = new G4AssemblyVolume();
-  G4RotationMatrix *noRot = new G4RotationMatrix();
-
   // let's find the total size of BabyMIND, this depends on the block sequence
   G4double BabyMINDTotalSizeZ = ComputeTotalSize();
+  G4double BabyMINDTotalSizeX = (fMagnetPlateSizeX > fHorizontalBarSizeX) ? fMagnetPlateSizeX : fHorizontalBarSizeX;
+  G4double BabyMINDTotalSizeY = (fMagnetPlateSizeY > fVerticalBarSizeY) ? fMagnetPlateSizeY : fVerticalBarSizeY;
   GeometricalParameters::Get()->SetBabyMINDTotalSizeZ(BabyMINDTotalSizeZ);
+
+  // create a top-level logical volume container
+  auto containerSolid = new G4Box("BabyMINDSolid", BabyMINDTotalSizeX/2., BabyMINDTotalSizeY/2., BabyMINDTotalSizeZ/2.);
+  fBabyMINDAssembly = new G4LogicalVolume(containerSolid, fMaterials->Material("Air"), "BabyMINDLogical");
 
   // center of the assembly is...
   G4ThreeVector BabyMINDCenter(0.,0.,0.);
+  G4RotationMatrix *noRot = new G4RotationMatrix();
 
   // starting position for placement
   G4ThreeVector prevPos(0.,0.,-BabyMINDTotalSizeZ/2.);
@@ -84,7 +88,7 @@ BabyMINDDetectorConstruction::BabyMINDDetectorConstruction()
         shift += fMagnetPlateThickness/2.;
         currentPos += G4ThreeVector(0.,0.,shift);
         // placing a magnet module
-        fBabyMINDAssembly->AddPlacedVolume(fMagnetPlate,currentPos,noRot);
+        new G4PVPlacement(noRot, currentPos, fMagnetPlate, "MagnetPlatePhysical", fBabyMINDLogical, false, 0, false);
         // update pointer to the end of the module
         // shift by only remaining half size
         shift = fMagnetPlateThickness/2.;
@@ -100,7 +104,7 @@ BabyMINDDetectorConstruction::BabyMINDDetectorConstruction()
         shift += 2*fBarThickness;
         currentPos += G4ThreeVector(0.,0.,shift);
         // placing a detector module
-        fBabyMINDAssembly->AddPlacedAssembly(fDetectorModule,currentPos,noRot);
+        fDetectorModule->MakeImprint(fBabyMINDAssembly, currentPos, noRot, 0, false);
         // update pointer to the end of the module
         // shift by only remaining half size
         shift = 2*fBarThickness; 

--- a/src/geometry/FASER2DetectorConstruction.cc
+++ b/src/geometry/FASER2DetectorConstruction.cc
@@ -1,4 +1,4 @@
-#include "geometry/SpectrometerMagnetConstruction.hh"
+#include "geometry/FASER2DetectorConstruction.hh"
 #include "geometry/GeometricalParameters.hh"
 #include "DetectorConstructionMaterial.hh"
 
@@ -14,21 +14,21 @@
 #include "G4PVReplica.hh"
 #include "G4PVPlacement.hh"
 
-SpectrometerMagnetConstruction::SpectrometerMagnetConstruction()
+FASER2DetectorConstruction::FASER2DetectorConstruction()
 {
   // load materials
   fMaterials = DetectorConstructionMaterial::GetInstance();
 
   // choose magnet option
-  GeometricalParameters::magnetOption opt = GeometricalParameters::Get()->GetSpectrometerMagnetOption(); 
+  GeometricalParameters::magnetOption opt = GeometricalParameters::Get()->GetFASER2MagnetOption(); 
   if( opt == GeometricalParameters::magnetOption::SAMURAI ){
     
     G4cout << "Building SAMURAI spectrometer magnet" << G4endl;
-    fMagnetWindowX = GeometricalParameters::Get()->GetSpectrometerMagnetWindowX();
-    fMagnetWindowY = GeometricalParameters::Get()->GetSpectrometerMagnetWindowY();
-    fMagnetWindowZ = GeometricalParameters::Get()->GetSpectrometerMagnetWindowZ();
-    fMagnetYokeThicknessX = GeometricalParameters::Get()->GetSpectrometerMagnetYokeThickX();
-    fMagnetYokeThicknessY = GeometricalParameters::Get()->GetSpectrometerMagnetYokeThickY();
+    fMagnetWindowX = GeometricalParameters::Get()->GetFASER2MagnetWindowX();
+    fMagnetWindowY = GeometricalParameters::Get()->GetFASER2MagnetWindowY();
+    fMagnetWindowZ = GeometricalParameters::Get()->GetFASER2MagnetWindowZ();
+    fMagnetYokeThicknessX = GeometricalParameters::Get()->GetFASER2MagnetYokeThickX();
+    fMagnetYokeThicknessY = GeometricalParameters::Get()->GetFASER2MagnetYokeThickY();
    
     fNTrackingStations = GeometricalParameters::Get()->GetNTrackingStations();
     fTrackingStationX = fMagnetWindowX + 0.5*m; //match magnet size + bending plane
@@ -79,11 +79,11 @@ SpectrometerMagnetConstruction::SpectrometerMagnetConstruction()
   } else if ( opt == GeometricalParameters::magnetOption::CrystalPulling ){
  
     G4cout << "Building CrystalPulling spectrometer magnet" << G4endl;
-    fMagnetLengthZ = GeometricalParameters::Get()->GetSpectrometerMagnetLengthZ();
-    fMagnetInnerR = GeometricalParameters::Get()->GetSpectrometerMagnetInnerR();
-    fMagnetOuterR = GeometricalParameters::Get()->GetSpectrometerMagnetOuterR();
-    fNMagnets = GeometricalParameters::Get()->GetNSpectrometerMagnets();
-    fMagnetGap = GeometricalParameters::Get()->GetSpectrometerMagnetGap();
+    fMagnetLengthZ = GeometricalParameters::Get()->GetFASER2MagnetLengthZ();
+    fMagnetInnerR = GeometricalParameters::Get()->GetFASER2MagnetInnerR();
+    fMagnetOuterR = GeometricalParameters::Get()->GetFASER2MagnetOuterR();
+    fNMagnets = GeometricalParameters::Get()->GetNFASER2Magnets();
+    fMagnetGap = GeometricalParameters::Get()->GetFASER2MagnetGap();
     
     fNTrackingStations = GeometricalParameters::Get()->GetNTrackingStations();
     fTrackingStationX = 2*fMagnetInnerR + 0.5*m ; //match magnet size + bending plane (for now, FIXME?)
@@ -123,7 +123,7 @@ SpectrometerMagnetConstruction::SpectrometerMagnetConstruction()
     // each magnet comes with a set of N tracking stations just before it
     // the gap between each magnet is then given by magnetSpacing
     G4double magnetSpacing = 2*fMagnetGap + totThickness;
-    GeometricalParameters::Get()->SetSpectrometerMagnetSpacing(magnetSpacing);    
+    GeometricalParameters::Get()->SetFASER2MagnetSpacing(magnetSpacing);    
 
     for(int i=0; i<fNMagnets; i++){
       G4double offset = (i-0.5*(fNMagnets-1))*(magnetSpacing+fMagnetLengthZ);
@@ -169,14 +169,14 @@ SpectrometerMagnetConstruction::SpectrometerMagnetConstruction()
   fVerTrackingScinBar->SetVisAttributes(stationVis);  
 }
 
-SpectrometerMagnetConstruction::~SpectrometerMagnetConstruction()
+FASER2DetectorConstruction::~FASER2DetectorConstruction()
 { 
   delete fFASER2Assembly;
   delete fMagnetWindow;
   delete fMagnetYoke;
 }
 
-void SpectrometerMagnetConstruction::BuildSAMURAIDesign()
+void FASER2DetectorConstruction::BuildSAMURAIDesign()
 {
   auto magnetYokeBlock = new G4Box("MagnetYokeBlock", fMagnetWindowX/2.+fMagnetYokeThicknessX, fMagnetWindowY/2.+fMagnetYokeThicknessY, fMagnetWindowZ/2.);
   auto magnetWindowSolid = new G4Box("MagnetYokeWindow", fMagnetWindowX/2., fMagnetWindowY/2., fMagnetWindowZ/2.);
@@ -190,7 +190,7 @@ void SpectrometerMagnetConstruction::BuildSAMURAIDesign()
   fMagnetWindow = new G4LogicalVolume(magnetWindowSolid, fMaterials->Material("Air"), "FASER2MagnetWindowLogical"); 
 }
 
-void SpectrometerMagnetConstruction::BuildCrystalPullingDesign()
+void FASER2DetectorConstruction::BuildCrystalPullingDesign()
 {
   auto magnetWindowSolid = new G4Tubs("MagnetWindow",0.,fMagnetInnerR,fMagnetLengthZ/2.,0.,CLHEP::twopi);
   auto magnetYokeSolid = new G4Tubs("MagnetYoke",fMagnetInnerR,fMagnetOuterR,fMagnetLengthZ/2.,0.,CLHEP::twopi);
@@ -199,7 +199,7 @@ void SpectrometerMagnetConstruction::BuildCrystalPullingDesign()
   fMagnetWindow = new G4LogicalVolume(magnetWindowSolid, fMaterials->Material("Air"), "FASER2MagnetWindowLogical");
 }
 
-void SpectrometerMagnetConstruction::BuildTrackingStation()
+void FASER2DetectorConstruction::BuildTrackingStation()
 {
   // Each tracking station is made of 2 layers
   // 1st layer: fNScinBarsY horizontal modules

--- a/src/geometry/FASERnu2DetectorConstruction.cc
+++ b/src/geometry/FASERnu2DetectorConstruction.cc
@@ -10,6 +10,7 @@
 #include "G4Colour.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4PVReplica.hh"
+#include "G4PVPlacement.hh"
 
 FASERnu2DetectorConstruction::FASERnu2DetectorConstruction()
 {

--- a/src/geometry/FLArEHadCatcherMuonFinderConstruction.cc
+++ b/src/geometry/FLArEHadCatcherMuonFinderConstruction.cc
@@ -12,6 +12,7 @@
 #include "G4Colour.hh" 
 #include "G4PVReplica.hh"
 #include "G4UserLimits.hh"
+#include "G4PVPlacement.hh"
 
 FLArEHadCatcherMuonFinderConstruction::FLArEHadCatcherMuonFinderConstruction()
 {
@@ -25,18 +26,20 @@ FLArEHadCatcherMuonFinderConstruction::FLArEHadCatcherMuonFinderConstruction()
   BuildFLArEHadCal();
   BuildFLArEMuonCatcher();
 
-  fHadCatcherMuonFinderAssembly = new G4AssemblyVolume();
+  G4double totalLength = fHadCalLength + fMuonCatcherLength;
+  auto containerSolid = new G4Box("HadCatcherMuonFinderContainer",fLArSizeX/2.,fLArSizeY/2.,totalLength/2.);
+  fHadCatcherMuonFinderAssembly = new G4LogicalVolume(containerSolid, fMaterials->Material("Air"), "HadCatcherMuonFinderLogical");
+
   G4RotationMatrix* noRot = new G4RotationMatrix();
   G4ThreeVector assemblyCenter(0.,0.,0.);
-  G4double totalLength = fHadCalLength + fMuonCatcherLength;
-
+  
   // HadCal
   G4ThreeVector hadCalCenter(0.,0.,-totalLength/2. +fHadCalLength/2.);
-  fHadCatcherMuonFinderAssembly->AddPlacedAssembly(HadCalAssembly,hadCalCenter,noRot);
+  HadCalAssembly->MakeImprint(fHadCatcherMuonFinderAssembly, hadCalCenter, noRot, 0, false);
 
   // MuonCatcher
   G4ThreeVector MuonCatcherCenter(0.,0.,-totalLength/2.+fHadCalLength+fMuonCatcherLength/2.);
-  fHadCatcherMuonFinderAssembly->AddPlacedAssembly(MuonCatcherAssembly,MuonCatcherCenter,noRot);
+  MuonCatcherAssembly->MakeImprint(fHadCatcherMuonFinderAssembly, MuonCatcherCenter, noRot, 0, false);
 
   // visualization
   G4VisAttributes* absorVis = new G4VisAttributes(G4Colour(234./255, 173./255, 26./255, 0.8));

--- a/src/geometry/FLArETPCDetectorConstruction.cc
+++ b/src/geometry/FLArETPCDetectorConstruction.cc
@@ -47,8 +47,8 @@ FLArETPCDetectorConstruction::FLArETPCDetectorConstruction()
   G4double halfContainerX = fLArSizeX/2. + fThicknessInsulation;
   G4double halfContainerY = fLArSizeY/2. + fThicknessInsulation;
   G4double halfContainerZ = fLArSizeZ/2. + fThicknessInsulation;
-  auto containerSolid = new G4Box("FLArETPCContainerSolid", halfContainerX, halfContainerY, halfContainerZ);
-  fFLArETPCLogical = new G4LogicalVolume(containerSolid, fMaterials->Material("Air"), "FLArETPCLogical");
+  auto containerSolid = new G4Box("FLArESolid", halfContainerX, halfContainerY, halfContainerZ);
+  fFLArETPCAssembly = new G4LogicalVolume(containerSolid, fMaterials->Material("Air"), "FLArELogical");
 
   // TPC
   G4ThreeVector tpcCenter(0.,0.,0.);

--- a/src/geometry/FLArETPCDetectorConstruction.cc
+++ b/src/geometry/FLArETPCDetectorConstruction.cc
@@ -12,6 +12,7 @@
 #include "G4Colour.hh" 
 #include "G4PVReplica.hh"
 #include "G4UserLimits.hh"
+#include "G4PVPlacement.hh"
 
 FLArETPCDetectorConstruction::FLArETPCDetectorConstruction()
 {
@@ -43,19 +44,23 @@ FLArETPCDetectorConstruction::FLArETPCDetectorConstruction()
   BuildFLArETPC();
   BuildCryostatInsulation();
 
-  fFLArETPCAssembly = new G4AssemblyVolume();
-  G4RotationMatrix* noRot = new G4RotationMatrix();
+  G4double halfContainerX = fLArSizeX/2. + fThicknessInsulation;
+  G4double halfContainerY = fLArSizeY/2. + fThicknessInsulation;
+  G4double halfContainerZ = fLArSizeZ/2. + fThicknessInsulation;
+  auto containerSolid = new G4Box("FLArETPCContainerSolid", halfContainerX, halfContainerY, halfContainerZ);
+  fFLArETPCLogical = new G4LogicalVolume(containerSolid, fMaterials->Material("Air"), "FLArETPCLogical");
 
   // TPC
   G4ThreeVector tpcCenter(0.,0.,0.);
+  G4RotationMatrix* noRot = new G4RotationMatrix();
   if (fDetGeomOption == GeometricalParameters::tpcConfigOption::Single) {
-    fFLArETPCAssembly->AddPlacedVolume(fFLArETPCLog, tpcCenter, noRot);
+    new G4PVPlacement(noRot, tpcCenter, fFLArETPCLog, "LArPhysical", fFLArETPCAssembly, false, 0, false);
   } else if (fDetGeomOption == GeometricalParameters::tpcConfigOption::ThreeBySeven) {
-    fFLArETPCAssembly->AddPlacedVolume(lArBoxLog, tpcCenter, noRot);
+    new G4PVPlacement(noRot, tpcCenter, lArBoxLog, "LArPhysical", fFLArETPCAssembly, false, 0, false);
   } else {
     G4cout << "ERROR: undefined TPC configuration!" << G4endl;  
   }
-  fFLArETPCAssembly->AddPlacedVolume(cryoInsulationLog, tpcCenter, noRot);
+  new G4PVPlacement(noRot, tpcCenter, cryoInsulationLog, "CryostatPhysical", fFLArETPCAssembly, false, 0, false);
 
 }
 

--- a/src/geometry/FORMOSADetectorConstruction.cc
+++ b/src/geometry/FORMOSADetectorConstruction.cc
@@ -29,8 +29,8 @@ FORMOSADetectorConstruction::FORMOSADetectorConstruction()
   fPMTSizeSpacing = GeometricalParameters::Get()->GetPMTSizeSpacing();
 
   G4double totLengthZ = NScintillatorModules*(fScintillatorBarSizeZ+fPMTSizeSpacing);
-  Gedouble totLengthX = fNScinBarsX*fScintillatorBarSizeX;
-  Gedouble totLengthY = fNScinBarsY*fScintillatorBarSizeY;
+  G4double totLengthX = fNScinBarsX*fScintillatorBarSizeX;
+  G4double totLengthY = fNScinBarsY*fScintillatorBarSizeY;
   GeometricalParameters::Get()->SetFORMOSATotalSizeZ(totLengthZ);
 
   BuildScintillatorAssembly();

--- a/src/geometry/FORMOSADetectorConstruction.cc
+++ b/src/geometry/FORMOSADetectorConstruction.cc
@@ -10,6 +10,7 @@
 #include "G4Colour.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4PVReplica.hh"
+#include "G4PVPlacement.hh"
 
 FORMOSADetectorConstruction::FORMOSADetectorConstruction()
 {
@@ -28,23 +29,26 @@ FORMOSADetectorConstruction::FORMOSADetectorConstruction()
   fPMTSizeSpacing = GeometricalParameters::Get()->GetPMTSizeSpacing();
 
   G4double totLengthZ = NScintillatorModules*(fScintillatorBarSizeZ+fPMTSizeSpacing);
+  Gedouble totLengthX = fNScinBarsX*fScintillatorBarSizeX;
+  Gedouble totLengthY = fNScinBarsY*fScintillatorBarSizeY;
   GeometricalParameters::Get()->SetFORMOSATotalSizeZ(totLengthZ);
 
   BuildScintillatorAssembly();
   //BuildVetoDetector(); 
     
-  fFORMOSAAssembly = new G4AssemblyVolume();
-  G4RotationMatrix *noRot = new G4RotationMatrix();
+  auto containerSolid = new G4Box("FORMOSASolid",totLengthX/2.,totLengthY/2.,totLengthZ/2.);
+  fFORMOSAAssembly = new G4LogicalVolume(containerSolid, fMaterials->Material("Air"), "FORMOSALogical");
 
   // center of the assembly is the center of middle PMT box
   G4ThreeVector FORMOSACenter(0.,0.,0.);
+  G4RotationMatrix *noRot = new G4RotationMatrix();
 
   // placing the scintillator blocks: note that the center of each scintillator assembly
   // is in the middle of the scintillator, not in the geometrical baricenter
   for( int i=0; i<NScintillatorModules; i++ ){
     G4double offset = -0.5*(3.*fScintillatorBarSizeZ+4.*fPMTSizeSpacing)+i*(fScintillatorBarSizeZ+fPMTSizeSpacing);
     G4ThreeVector pos = FORMOSACenter + G4ThreeVector(0.,0., offset);
-    fFORMOSAAssembly->AddPlacedAssembly(fScintillatorAssembly,pos,noRot);
+    fScintillatorAssembly->MakeImprint(fFORMOSAAssembly, pos, noRot, 0, false);
   }
 
   // placing the outer veto detectors

--- a/src/geometry/GeometricalParameters.cc
+++ b/src/geometry/GeometricalParameters.cc
@@ -48,25 +48,25 @@ GeometricalParameters::GeometricalParameters()
   fBabyMINDBlockSequence = "|MMMMD||DMMMD||DMMMMD||MMDMMD||MMDMMD||MDMDMD||DMMMD|";
 
   // FASER2 magnet
-  fSpectrometerMagnetOption = magnetOption::SAMURAI;
-  fSpectrometerMagnetField = 1.0*tesla;
+  fFASER2MagnetOption = magnetOption::SAMURAI;
+  fFASER2MagnetField = 1.0*tesla;
   fMagnetTotalSizeZ = 4*m; //updates during construction
   fTrackingStationTotalSizeZ = 2.62*m; //updates during construction
   fMagnetZPos = 40*m; //updates during construction
   fFASER2TotalSizeZ = 10.24*m;
   // SAMURAI design
-  fSpectrometerMagnetWindowX = 3.0*m;
-  fSpectrometerMagnetWindowY = 1.0*m;
-  fSpectrometerMagnetWindowZ = 4.0*m;
-  fSpectrometerMagnetYokeThickX = 1.5*m;
-  fSpectrometerMagnetYokeThickY = 2.0*m;
+  fFASER2MagnetWindowX = 3.0*m;
+  fFASER2MagnetWindowY = 1.0*m;
+  fFASER2MagnetWindowZ = 4.0*m;
+  fFASER2MagnetYokeThickX = 1.5*m;
+  fFASER2MagnetYokeThickY = 2.0*m;
   // CrystalPulling design
-  fSpectrometerMagnetLengthZ = 1.25*m;
-  fSpectrometerMagnetInnerR = 0.8*m;
-  fSpectrometerMagnetOuterR = 1.2*m;
-  fNSpectrometerMagnets = 3;
-  fSpectrometerMagnetGap = 0.25*m;
-  fSpectrometerMagnetSpacing = 0.76*m; //updates during construction
+  fFASER2MagnetLengthZ = 1.25*m;
+  fFASER2MagnetInnerR = 0.8*m;
+  fFASER2MagnetOuterR = 1.2*m;
+  fNFASER2Magnets = 3;
+  fFASER2MagnetGap = 0.25*m;
+  fFASER2MagnetSpacing = 0.76*m; //updates during construction
   // Tracking stations
   fNTrackingStations = 6;
   fNScintillatorBarsY = 3;
@@ -142,12 +142,12 @@ GeometricalParameters::magnetOption GeometricalParameters::ConvertStringToMagnet
   }
 }
 
-G4ThreeVector GeometricalParameters::GetSpectrometerMagnetField()
+G4ThreeVector GeometricalParameters::GetFASER2MagnetField()
 {
-  if (fSpectrometerMagnetOption == magnetOption::SAMURAI )
-    return G4ThreeVector(0.,fSpectrometerMagnetField,0.); //field along Y
-  else if (fSpectrometerMagnetOption == magnetOption::CrystalPulling)     
-    return G4ThreeVector(0.,fSpectrometerMagnetField,0.); //field along Y (for now, FIXME?)
+  if (fFASER2MagnetOption == magnetOption::SAMURAI )
+    return G4ThreeVector(0.,fFASER2MagnetField,0.); //field along Y
+  else if (fFASER2MagnetOption == magnetOption::CrystalPulling)     
+    return G4ThreeVector(0.,fFASER2MagnetField,0.); //field along Y (for now, FIXME?)
   else
     return G4ThreeVector(0.,0.,0.);
 }

--- a/src/geometry/SpectrometerMagnetConstruction.cc
+++ b/src/geometry/SpectrometerMagnetConstruction.cc
@@ -105,8 +105,8 @@ SpectrometerMagnetConstruction::SpectrometerMagnetConstruction()
      
     // total length (all magnets, all tracking stations sets, all gaps)
     G4double totalLengthZ = 2*(totThickness+fMagnetGap) + magnetsLengthZ;
-    G4doulle totalLengthY = 2*fMagnetOuterR;
-    G4doulle totalLengthX = 2*fMagnetOuterR;
+    G4double totalLengthY = 2*fMagnetOuterR;
+    G4double totalLengthX = 2*fMagnetOuterR;
     GeometricalParameters::Get()->SetFASER2TotalSizeZ(totalLengthZ);    
 
     BuildCrystalPullingDesign(); //sets logical volumes
@@ -171,7 +171,7 @@ SpectrometerMagnetConstruction::SpectrometerMagnetConstruction()
 
 SpectrometerMagnetConstruction::~SpectrometerMagnetConstruction()
 { 
-  delete fMagnetAssembly;
+  delete fFASER2Assembly;
   delete fMagnetWindow;
   delete fMagnetYoke;
 }

--- a/src/geometry/SpectrometerMagnetConstruction.cc
+++ b/src/geometry/SpectrometerMagnetConstruction.cc
@@ -12,6 +12,7 @@
 #include "G4Colour.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4PVReplica.hh"
+#include "G4PVPlacement.hh"
 
 SpectrometerMagnetConstruction::SpectrometerMagnetConstruction()
 {
@@ -39,23 +40,27 @@ SpectrometerMagnetConstruction::SpectrometerMagnetConstruction()
     G4double gapToMagnet = fTrackingStationGap;
     G4double stationThickness = 2*fScinThickness;
     G4double totThickness = fNTrackingStations*stationThickness + (fNTrackingStations-1)*fTrackingStationGap;
-   
+    G4double totLengthZ = fMagnetWindowZ+2*gapToMagnet+2*totThickness;
+    G4double totLengthX = fMagnetWindowX+2*fMagnetYokeThicknessX;
+    G4double totLengthY = fMagnetWindowY+2*fMagnetYokeThicknessY;
+
     GeometricalParameters::Get()->SetMagnetTotalSizeZ(fMagnetWindowZ);
     GeometricalParameters::Get()->SetTrackingStationTotalSizeZ(totThickness);
-    GeometricalParameters::Get()->SetFASER2TotalSizeZ(fMagnetWindowZ+2*gapToMagnet+2*totThickness);
+    GeometricalParameters::Get()->SetFASER2TotalSizeZ(totLengthZ);
 
     BuildSAMURAIDesign(); //sets logical volumes
     BuildTrackingStation(); //sets assembly volume
     
-    fMagnetAssembly = new G4AssemblyVolume();
-    G4RotationMatrix *noRot = new G4RotationMatrix();
+    auto containerSolid = new G4Box("FASER2Solid", totLengthX/2., totLengthY/2., totLengthZ/2.);
+    fFASER2Assembly = new G4LogicalVolume(containerSolid, fMaterials->Material("Air"), "FASER2Logical");
 
     // center of the assembly is the center of the magnet window
     G4ThreeVector magCenter(0.,0.,0.);
+    G4RotationMatrix *noRot = new G4RotationMatrix();
 
     // placing magnet + yoke
-    fMagnetAssembly->AddPlacedVolume(fMagnetWindow,magCenter,noRot);
-    fMagnetAssembly->AddPlacedVolume(fMagnetYoke,magCenter,noRot);
+    new G4PVPlacement(noRot, magCenter, fMagnetWindow, "FASER2MagnetWindowPhysical", fFASER2Assembly, false, 0, false);
+    new G4PVPlacement(noRot, magCenter, fMagnetYoke, "FASER2MagnetYokePhysical", fFASER2Assembly, false, 0, false);
 
     // middle position of pre-magnet and post-magnet tracking stations
     G4ThreeVector offset(0, 0, fMagnetWindowZ/2.+ gapToMagnet + totThickness/2.);
@@ -67,8 +72,8 @@ SpectrometerMagnetConstruction::SpectrometerMagnetConstruction()
       G4ThreeVector T(0, 0, -totThickness/2.+0.5*stationThickness+i*(fTrackingStationGap+stationThickness));
       G4ThreeVector Tp = postStationsCenter + T;
       G4ThreeVector Tm = preStationsCenter + T;
-      fMagnetAssembly->AddPlacedAssembly(fTrackingStation, Tm, noRot); //place before magnet
-      fMagnetAssembly->AddPlacedAssembly(fTrackingStation, Tp, noRot); //place after magnet
+      fTrackingStation->MakeImprint(fFASER2Assembly, Tm, noRot, 0, false); //place before magnet
+      fTrackingStation->MakeImprint(fFASER2Assembly, Tp, noRot, 0, false); //place after magnet
     }
 
   } else if ( opt == GeometricalParameters::magnetOption::CrystalPulling ){
@@ -100,17 +105,20 @@ SpectrometerMagnetConstruction::SpectrometerMagnetConstruction()
      
     // total length (all magnets, all tracking stations sets, all gaps)
     G4double totalLengthZ = 2*(totThickness+fMagnetGap) + magnetsLengthZ;
+    G4doulle totalLengthY = 2*fMagnetOuterR;
+    G4doulle totalLengthX = 2*fMagnetOuterR;
     GeometricalParameters::Get()->SetFASER2TotalSizeZ(totalLengthZ);    
 
     BuildCrystalPullingDesign(); //sets logical volumes
     BuildTrackingStation();
     
-    fMagnetAssembly = new G4AssemblyVolume();
-    G4RotationMatrix *noRot = new G4RotationMatrix();
+    auto containerSolid = new G4Box("FASER2Solid", totalLengthX/2., totalLengthY/2., totalLengthZ/2.);
+    fFASER2Assembly = new G4LogicalVolume(containerSolid, fMaterials->Material("Air"), "FASER2Logical");
 
     // center of the assembly is the center of middle magnet window
     // if fNMagnets is even, it falls in the gap between the two middle magnets
     G4ThreeVector magCenter(0.,0.,0.);
+    G4RotationMatrix *noRot = new G4RotationMatrix();
    
     // each magnet comes with a set of N tracking stations just before it
     // the gap between each magnet is then given by magnetSpacing
@@ -120,15 +128,15 @@ SpectrometerMagnetConstruction::SpectrometerMagnetConstruction()
     for(int i=0; i<fNMagnets; i++){
       G4double offset = (i-0.5*(fNMagnets-1))*(magnetSpacing+fMagnetLengthZ);
       G4ThreeVector magPos = magCenter + G4ThreeVector(0.,0.,offset);
-      fMagnetAssembly->AddPlacedVolume(fMagnetWindow,magPos,noRot);
-      fMagnetAssembly->AddPlacedVolume(fMagnetYoke,magPos,noRot);
+      new G4PVPlacement(noRot, magPos, fMagnetWindow, "FASER2MagnetWindowPhysical", fFASER2Assembly, false, i, false);
+      new G4PVPlacement(noRot, magPos, fMagnetYoke, "FASER2MagnetYokePhysical", fFASER2Assembly, false, i, false);
 
       // placing tracking stations (before each magnet)
       G4double trackingStationOffset = -fMagnetGap-0.5*fMagnetLengthZ;
       for (int j= 0; j<fNTrackingStations; ++j) { 
         G4ThreeVector T(0., 0., trackingStationOffset-j*fTrackingStationGap-0.5*(i+1)*stationThickness);
         G4ThreeVector Tpos = magPos + T; 
-        fMagnetAssembly->AddPlacedAssembly(fTrackingStation, Tpos, noRot);
+        fTrackingStation->MakeImprint(fFASER2Assembly, Tpos, noRot, i, false); 
       }
     }
     
@@ -139,7 +147,7 @@ SpectrometerMagnetConstruction::SpectrometerMagnetConstruction()
     for (int i= 0; i<fNTrackingStations; ++i) { 
       G4ThreeVector T(0, 0, -totThickness/2.+0.5*stationThickness+i*(fTrackingStationGap+stationThickness));
       G4ThreeVector Tp = postStationsCenter + T;
-      fMagnetAssembly->AddPlacedAssembly(fTrackingStation, Tp, noRot);
+      fTrackingStation->MakeImprint(fFASER2Assembly, Tp, noRot, fNMagnets, false);
     }
    
   } else {

--- a/src/reco/CircleFit.cc
+++ b/src/reco/CircleFit.cc
@@ -182,7 +182,7 @@ namespace circularfitter {
     // two cases depending on the magnet design:
     // there can be many magnets, so many magnet positions
     // get the magnet position(s) for each geometry (SAMURAI or CrystalPulling design) first
-    GeometricalParameters::magnetOption opt = GeometricalParameters::Get()->GetSpectrometerMagnetOption();
+    GeometricalParameters::magnetOption opt = GeometricalParameters::Get()->GetFASER2MagnetOption();
     G4int nmag = 0;
     std::vector<double> zin;
     std::vector<double> zout;
@@ -200,9 +200,9 @@ namespace circularfitter {
     }else if ( opt == GeometricalParameters::magnetOption::CrystalPulling ){
       
       double zcenter = GeometricalParameters::Get()->GetMagnetZPosition();
-      double size = GeometricalParameters::Get()->GetSpectrometerMagnetLengthZ();
-      double spacing = GeometricalParameters::Get()->GetSpectrometerMagnetSpacing();
-      nmag = GeometricalParameters::Get()->GetNSpectrometerMagnets();
+      double size = GeometricalParameters::Get()->GetFASER2MagnetLengthZ();
+      double spacing = GeometricalParameters::Get()->GetFASER2MagnetSpacing();
+      nmag = GeometricalParameters::Get()->GetNFASER2Magnets();
       for(int i=0; i<nmag; i++){
 	double offset = (i-0.5*(nmag-1))*(spacing+size);
 	fzpos.push_back( zcenter + offset );


### PR DESCRIPTION
Closes #52 

Key changes include:
- Each detector class now returns a top-level `G4LogicalVolume` (instead of `G4AssemblyVolume`).  This eliminates nested assemblies in the final geometry tree.
- `SpectrometerMagnetConstruction` class is renamed `FASER2DetectorConstruction`.
- Hardcoded GDML output name is changed to `FPF_FLArE_geo`.