### PR TITLE
Add link to FPFSIM in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FLArE
 
+ ## <span style="color:red"> This repository has moved! Please go to [FPFSoftware/FPFSim](https://github.com/FPFSoftware/FPFSim) </span>
+
 Simulation code for R&D of the FLArE detector
 ![nutau evt display](./flare_nutau_evd.jpg)
 


### PR DESCRIPTION
Now that we have migrated the repository we should add a note in the README to point people to the new repo location in case anyone finds the page through an old link 

Changes:
- Added header to README pointing people to https://github.com/FPFSoftware/FPFSim